### PR TITLE
Add overfitting detection: drift, calibration, Monte Carlo, bootstrap CI

### DIFF
--- a/backend/app/api/routes/ml.py
+++ b/backend/app/api/routes/ml.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 
 import joblib
 from fastapi import APIRouter, Depends, HTTPException, Query
+from loguru import logger
 
 from app.auth import require_auth
 from pydantic import BaseModel, Field
@@ -122,7 +123,7 @@ async def train_model(req: TrainRequest):
                 train_end=df.index[split_idx].to_pydatetime(),
                 test_start=df.index[split_idx].to_pydatetime(),
                 test_end=df.index[-1].to_pydatetime(),
-                metrics=json.dumps(result.report),
+                metrics=json.dumps(result.to_dict()),
                 feature_importance=json.dumps(result.feature_importance),
                 model_path=model_path,
                 model_binary=model_bytes,
@@ -256,6 +257,28 @@ async def predict_now(symbol: str = Query("GOLD")):
     signal, confidence = predictor.predict(df_recent)
 
     signal_label = {1: "BUY", -1: "SELL", 0: "HOLD"}[signal]
+
+    # Log prediction to DB for calibration analysis
+    try:
+        from app.db.models import MLPredictionLog, MLModelLog
+        model_result = await _db_session.execute(
+            select(MLModelLog).where(
+                MLModelLog.is_active == True,
+                MLModelLog.model_name.like(f"{model_prefix}%"),
+            ).limit(1)
+        )
+        model_log = model_result.scalar_one_or_none()
+        pred_log = MLPredictionLog(
+            model_id=model_log.id if model_log else None,
+            symbol=symbol,
+            predicted_signal=signal,
+            confidence=confidence,
+        )
+        _db_session.add(pred_log)
+        await _db_session.commit()
+    except Exception:
+        await _db_session.rollback()
+
     return {
         "signal": signal_label,
         "signal_value": signal,
@@ -299,9 +322,26 @@ async def get_drift_report(symbol: str = Query("GOLD")):
     predictions = pred_result.scalars().all()
     recent_signals = [p.predicted_signal for p in predictions]
 
+    # Build live features for feature drift comparison
+    live_features = None
+    if training_stats and _collector is not None:
+        try:
+            from app.ml.features import build_features
+            from app.config import SYMBOL_PROFILES, settings as app_settings
+            tf = SYMBOL_PROFILES.get(symbol, {}).get("ml_timeframe", app_settings.timeframe)
+            df = await _collector.load_from_db(symbol, tf)
+            if not df.empty and len(df) >= 200:
+                features = build_features(df.tail(300))
+                available = [c for c in training_stats.keys() if c in features.columns]
+                if available:
+                    live_features = features[available].dropna()
+        except Exception as e:
+            logger.warning(f"Failed to build live features for drift: {e}")
+
     report = check_drift(
         training_stats=training_stats,
         training_label_dist=training_label_dist,
+        live_features=live_features,
         recent_predictions=recent_signals if recent_signals else None,
     )
     return report.to_dict()

--- a/backend/app/backtest/walk_forward.py
+++ b/backend/app/backtest/walk_forward.py
@@ -5,6 +5,7 @@ Detects overfitting by comparing in-sample vs out-of-sample performance.
 
 from dataclasses import dataclass, field
 
+import numpy as np
 import pandas as pd
 from loguru import logger
 
@@ -26,9 +27,12 @@ class WalkForwardResult:
     overfitting_ratio: float = 0.0  # OOS sharpe / IS sharpe
     likely_overfit: bool = False
     best_params_stability: list[dict] = field(default_factory=list)
+    oos_sharpe_ci: tuple[float, float] | None = None  # 95% bootstrap CI
+    param_stability_score: float | None = None  # avg coefficient of variation (lower=better)
+    param_stability_detail: dict = field(default_factory=dict)  # per-param CV
 
     def to_dict(self) -> dict:
-        return {
+        d = {
             "n_splits": self.n_splits,
             "windows": self.windows,
             "aggregate_oos_sharpe": round(self.aggregate_oos_sharpe, 4),
@@ -40,6 +44,48 @@ class WalkForwardResult:
             "likely_overfit": self.likely_overfit,
             "best_params_stability": self.best_params_stability,
         }
+        if self.oos_sharpe_ci is not None:
+            d["oos_sharpe_ci"] = [round(self.oos_sharpe_ci[0], 4), round(self.oos_sharpe_ci[1], 4)]
+        if self.param_stability_score is not None:
+            d["param_stability_score"] = round(self.param_stability_score, 4)
+            d["param_stability_detail"] = {k: round(v, 4) for k, v in self.param_stability_detail.items()}
+        return d
+
+
+def bootstrap_ci(values: list[float], n_bootstrap: int = 1000, ci: float = 0.95) -> tuple[float, float]:
+    """Compute bootstrap confidence interval for the mean of values."""
+    arr = np.array(values)
+    rng = np.random.default_rng(42)
+    means = [rng.choice(arr, size=len(arr), replace=True).mean() for _ in range(n_bootstrap)]
+    lower = np.percentile(means, (1 - ci) / 2 * 100)
+    upper = np.percentile(means, (1 + ci) / 2 * 100)
+    return float(lower), float(upper)
+
+
+def compute_param_stability(params_list: list[dict]) -> tuple[float, dict[str, float]]:
+    """Compute coefficient of variation per parameter across walk-forward windows.
+    Returns (avg_cv, {param: cv}). Lower CV = more stable = less overfit."""
+    if len(params_list) < 2:
+        return 0.0, {}
+
+    all_keys = set()
+    for p in params_list:
+        all_keys.update(p.keys())
+
+    cvs = {}
+    for key in all_keys:
+        values = [p[key] for p in params_list if key in p and isinstance(p[key], (int, float))]
+        if len(values) < 2:
+            continue
+        arr = np.array(values, dtype=float)
+        mean = arr.mean()
+        if mean == 0:
+            cvs[key] = 0.0
+        else:
+            cvs[key] = float(arr.std() / abs(mean))
+
+    avg_cv = sum(cvs.values()) / len(cvs) if cvs else 0.0
+    return avg_cv, cvs
 
 
 def walk_forward_test(
@@ -149,5 +195,15 @@ def walk_forward_test(
         if result.in_sample_avg_sharpe > 0:
             result.overfitting_ratio = result.aggregate_oos_sharpe / result.in_sample_avg_sharpe
         result.likely_overfit = result.overfitting_ratio < 0.5 and result.in_sample_avg_sharpe > 0
+
+    # Bootstrap 95% CI on OOS Sharpe
+    if len(oos_sharpes) >= 3:
+        result.oos_sharpe_ci = bootstrap_ci(oos_sharpes)
+
+    # Parameter stability score
+    if len(result.best_params_stability) >= 2:
+        result.param_stability_score, result.param_stability_detail = compute_param_stability(
+            result.best_params_stability
+        )
 
     return result

--- a/backend/app/ml/trainer.py
+++ b/backend/app/ml/trainer.py
@@ -26,6 +26,8 @@ class TrainingResult:
     class_distribution: dict
     model_path: str
     walk_forward_results: list | None = None
+    feature_stats: dict | None = None
+    label_distribution: dict | None = None
 
     def to_dict(self) -> dict:
         d = {
@@ -43,6 +45,10 @@ class TrainingResult:
             d["walk_forward_avg_accuracy"] = round(
                 sum(f["accuracy"] for f in self.walk_forward_results) / len(self.walk_forward_results), 4
             )
+        if self.feature_stats:
+            d["feature_stats"] = self.feature_stats
+        if self.label_distribution:
+            d["label_distribution"] = self.label_distribution
         return d
 
 
@@ -167,6 +173,10 @@ class ModelTrainer:
             "BUY(1)": int((y == 1).sum()),
         }
 
+        # Feature stats for drift detection
+        feat_stats = self._compute_feature_stats(X_train)
+        label_dist = self._compute_label_distribution(y_train)
+
         logger.info(f"Model trained: accuracy={accuracy:.4f}, "
                      f"train={len(X_train)}, test={len(X_test)}")
 
@@ -179,7 +189,32 @@ class ModelTrainer:
             test_size=len(X_test),
             class_distribution=class_dist,
             model_path="",  # Set by caller after save
+            feature_stats=feat_stats,
+            label_distribution=label_dist,
         )
+
+    @staticmethod
+    def _compute_feature_stats(X_train: pd.DataFrame) -> dict:
+        """Compute per-feature statistics for drift detection."""
+        stats = {}
+        for col in X_train.columns:
+            stats[col] = {
+                "mean": float(X_train[col].mean()),
+                "std": float(X_train[col].std()),
+                "min": float(X_train[col].min()),
+                "max": float(X_train[col].max()),
+            }
+        return stats
+
+    @staticmethod
+    def _compute_label_distribution(y: pd.Series) -> dict:
+        """Compute label distribution as proportions."""
+        total = len(y)
+        return {
+            "sell": float((y == -1).sum() / total) if total > 0 else 0.0,
+            "hold": float((y == 0).sum() / total) if total > 0 else 0.0,
+            "buy": float((y == 1).sum() / total) if total > 0 else 0.0,
+        }
 
     def _get_params(self) -> dict:
         return {
@@ -311,6 +346,10 @@ class ModelTrainer:
             "BUY(1)": int((y == 1).sum()),
         }
 
+        # Feature stats for drift detection (use full training set 0-80%)
+        feat_stats = self._compute_feature_stats(X.iloc[:split_idx])
+        label_dist = self._compute_label_distribution(y.iloc[:split_idx])
+
         avg_acc = sum(f["accuracy"] for f in fold_results) / len(fold_results) if fold_results else accuracy
         logger.info(f"Walk-forward complete: avg_accuracy={avg_acc:.4f}, best_fold_accuracy={best_accuracy:.4f}")
 
@@ -324,6 +363,8 @@ class ModelTrainer:
             class_distribution=class_dist,
             model_path="",
             walk_forward_results=fold_results,
+            feature_stats=feat_stats,
+            label_distribution=label_dist,
         )
 
     def save_model(self, path: str):

--- a/frontend/app/backtest/page.tsx
+++ b/frontend/app/backtest/page.tsx
@@ -12,14 +12,14 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Play, BarChart3, TrendingUp, DollarSign, Target,
   AlertTriangle, Search, Loader2, FlaskConical, Zap, Footprints,
-  CheckCircle, XCircle,
+  CheckCircle, XCircle, Dice5,
 } from "lucide-react";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { PageInstructions } from "@/components/layout/PageInstructions";
 import { StatCard } from "@/components/ui/stat-card";
 import { TIMEFRAMES } from "@/components/ui/timeframe-selector";
 import {
-  runBacktest, runOptimize, runWalkForward, getCurrentStrategy, getDataStatus, getSymbols,
+  runBacktest, runOptimize, runWalkForward, runMonteCarlo, getCurrentStrategy, getDataStatus, getSymbols,
 } from "@/lib/api";
 import {
   AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
@@ -106,6 +106,9 @@ export default function BacktestPage() {
   const [wfRunning, setWfRunning] = useState(false);
   const [wfSplits, setWfSplits] = useState(5);
   const [wfTrainPct, setWfTrainPct] = useState(70);
+  // Monte Carlo state
+  const [mcResult, setMcResult] = useState<Record<string, unknown> | null>(null);
+  const [mcRunning, setMcRunning] = useState(false);
 
   const currentParams: ParamDef[] = STRATEGY_PARAMS[strategy] ?? [];
 
@@ -172,6 +175,20 @@ export default function BacktestPage() {
       const res = await runWalkForward(params as Parameters<typeof runWalkForward>[0]);
       setWfResult(res.data);
     } catch { /* handled */ } finally { setWfRunning(false); }
+  };
+
+  const handleMonteCarlo = async () => {
+    setMcRunning(true);
+    setMcResult(null);
+    try {
+      const params: Record<string, unknown> = {
+        strategy, symbol, timeframe, initial_balance: balance, source,
+      };
+      if (source === "db") { params.from_date = fromDate; params.to_date = toDate; }
+      else { params.count = count; }
+      const res = await runMonteCarlo(params as Parameters<typeof runMonteCarlo>[0]);
+      setMcResult(res.data);
+    } catch { /* handled */ } finally { setMcRunning(false); }
   };
 
   const equityCurve = (result?.equity_curve as number[] || []).map((v, i) => ({ bar: i, equity: v }));
@@ -266,10 +283,11 @@ export default function BacktestPage() {
       />
 
       <Tabs defaultValue="backtest" className="space-y-5">
-        <TabsList className="grid w-full grid-cols-3 max-w-md">
+        <TabsList className="grid w-full grid-cols-4 max-w-lg">
           <TabsTrigger value="backtest"><FlaskConical className="size-3.5 mr-1.5" />Backtest</TabsTrigger>
           <TabsTrigger value="optimize"><Zap className="size-3.5 mr-1.5" />Optimizer</TabsTrigger>
           <TabsTrigger value="walk-forward"><Footprints className="size-3.5 mr-1.5" />Walk Forward</TabsTrigger>
+          <TabsTrigger value="monte-carlo"><Dice5 className="size-3.5 mr-1.5" />Monte Carlo</TabsTrigger>
         </TabsList>
 
         {/* ── Backtest Tab ─────────────────────────────────────── */}
@@ -526,6 +544,12 @@ export default function BacktestPage() {
                   <p className="text-xs text-muted-foreground mt-0.5">
                     IS Sharpe: {(wfResult.in_sample_avg_sharpe as number).toFixed(3)} → OOS Sharpe: {(wfResult.aggregate_oos_sharpe as number).toFixed(3)} (ratio: {(wfResult.overfitting_ratio as number).toFixed(2)})
                     {(wfResult.overfitting_ratio as number) < 0.5 ? " — large performance drop out-of-sample" : " — performance holds out-of-sample"}
+                    {(wfResult.oos_sharpe_ci as number[]) && (
+                      <> | 95% CI: [{(wfResult.oos_sharpe_ci as number[])[0].toFixed(3)}, {(wfResult.oos_sharpe_ci as number[])[1].toFixed(3)}]</>
+                    )}
+                    {wfResult.param_stability_score != null && (
+                      <> | Param Stability: {(wfResult.param_stability_score as number).toFixed(3)} ({(wfResult.param_stability_score as number) < 0.3 ? "stable" : (wfResult.param_stability_score as number) < 0.6 ? "moderate" : "unstable"})</>
+                    )}
                   </p>
                 </div>
               </div>
@@ -616,6 +640,96 @@ export default function BacktestPage() {
             <div className="rounded-xl border border-red-500/20 bg-red-500/5 p-3 flex items-center gap-2">
               <AlertTriangle className="size-4 text-red-400 shrink-0" />
               <p className="text-sm text-red-400">{String(wfResult.error)}</p>
+            </div>
+          )}
+        </TabsContent>
+
+        {/* ── Monte Carlo Tab ────────────────────────────────── */}
+        <TabsContent value="monte-carlo" className="space-y-4 mt-0">
+          {configForm}
+
+          <div className="flex justify-end">
+            <Button onClick={handleMonteCarlo} disabled={mcRunning} className="rounded-lg font-medium min-w-35">
+              {mcRunning ? <Loader2 className="size-4 mr-1.5 animate-spin" /> : <Dice5 className="size-4 mr-1.5" />}
+              {mcRunning ? "Simulating..." : "Run Monte Carlo"}
+            </Button>
+          </div>
+
+          {mcResult && !mcResult.error && (
+            <div className="space-y-4">
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+                <StatCard
+                  icon={Target}
+                  label="P(Profit)"
+                  value={`${((mcResult.probability_of_profit as number) * 100).toFixed(1)}%`}
+                  variant={(mcResult.probability_of_profit as number) > 0.5 ? "success" : "danger"}
+                />
+                <StatCard
+                  icon={AlertTriangle}
+                  label="P(Ruin)"
+                  value={`${((mcResult.probability_of_ruin as number) * 100).toFixed(1)}%`}
+                  variant={(mcResult.probability_of_ruin as number) < 0.1 ? "success" : "danger"}
+                />
+                <StatCard
+                  icon={DollarSign}
+                  label="Median Balance"
+                  value={`$${(mcResult.median_final_balance as number).toFixed(0)}`}
+                  variant={(mcResult.median_final_balance as number) > (balance || 10000) ? "success" : "warning"}
+                />
+                <StatCard
+                  icon={TrendingUp}
+                  label="P95 Drawdown"
+                  value={`${((mcResult.p95_max_drawdown as number) * 100).toFixed(1)}%`}
+                  variant={(mcResult.p95_max_drawdown as number) < 0.3 ? "success" : "danger"}
+                />
+                <StatCard
+                  icon={BarChart3}
+                  label="Simulations"
+                  value={mcResult.n_simulations as number}
+                />
+              </div>
+
+              {/* Balance range */}
+              <div className="rounded-xl border border-border bg-card p-4">
+                <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">Balance Distribution (1,000 simulations)</h3>
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
+                  <div>
+                    <p className="text-[11px] text-muted-foreground">Pessimistic (P5)</p>
+                    <p className="font-bold font-mono text-red-400">${(mcResult.p5_final_balance as number).toFixed(0)}</p>
+                  </div>
+                  <div>
+                    <p className="text-[11px] text-muted-foreground">Median (P50)</p>
+                    <p className="font-bold font-mono">${(mcResult.median_final_balance as number).toFixed(0)}</p>
+                  </div>
+                  <div>
+                    <p className="text-[11px] text-muted-foreground">Mean</p>
+                    <p className="font-bold font-mono">${(mcResult.mean_final_balance as number).toFixed(0)}</p>
+                  </div>
+                  <div>
+                    <p className="text-[11px] text-muted-foreground">Optimistic (P95)</p>
+                    <p className="font-bold font-mono text-green-400">${(mcResult.p95_final_balance as number).toFixed(0)}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {!mcResult && !mcRunning && (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <div className="size-12 rounded-xl bg-muted flex items-center justify-center mb-3">
+                <Dice5 className="size-6 text-muted-foreground" />
+              </div>
+              <p className="text-sm font-semibold">No Monte Carlo results yet</p>
+              <p className="text-xs text-muted-foreground mt-1 max-w-xs">
+                Monte Carlo shuffles trade order 1,000 times to test if profits depend on lucky sequence or real edge.
+              </p>
+            </div>
+          )}
+
+          {mcResult && "error" in mcResult && (
+            <div className="rounded-xl border border-red-500/20 bg-red-500/5 p-3 flex items-center gap-2">
+              <AlertTriangle className="size-4 text-red-400 shrink-0" />
+              <p className="text-sm text-red-400">{String(mcResult.error)}</p>
             </div>
           )}
         </TabsContent>

--- a/frontend/app/ml/page.tsx
+++ b/frontend/app/ml/page.tsx
@@ -6,10 +6,11 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Brain, Play, Zap, BarChart3, Target, TrendingUp, Database, CheckCircle2, XCircle, ChevronDown, ChevronUp } from "lucide-react";
+import { Brain, Play, Zap, BarChart3, Target, TrendingUp, Database, CheckCircle2, XCircle, ChevronDown, ChevronUp, AlertTriangle, Activity, Loader2 } from "lucide-react";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { PageInstructions } from "@/components/layout/PageInstructions";
-import { trainModel, getModelStatus, mlPredict, getDataStatus, collectData, getSymbols } from "@/lib/api";
+import { trainModel, getModelStatus, mlPredict, getDataStatus, collectData, getSymbols, getDriftReport, getCalibration } from "@/lib/api";
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, ReferenceLine, Cell } from "recharts";
 import { SymbolTabs } from "@/components/ui/symbol-tabs";
 import { TIMEFRAMES } from "@/components/ui/timeframe-selector";
 
@@ -32,6 +33,10 @@ export default function MLPage() {
   const [collectResult, setCollectResult] = useState<{ total_bars_fetched: number; new_bars_inserted: number } | null>(null);
   const [collectError, setCollectError] = useState<string | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [driftReport, setDriftReport] = useState<Record<string, unknown> | null>(null);
+  const [driftLoading, setDriftLoading] = useState(false);
+  const [calibration, setCalibration] = useState<Record<string, unknown> | null>(null);
+  const [calibLoading, setCalibLoading] = useState(false);
 
   const [collectTimeframe, setCollectTimeframe] = useState("M15");
   const [trainTimeframe, setTrainTimeframe] = useState("M15");
@@ -133,6 +138,24 @@ export default function MLPage() {
       setPrediction(res.data);
     } catch { /* handled */ }
     finally { setPredicting(false); }
+  };
+
+  const handleDrift = async () => {
+    setDriftLoading(true);
+    try {
+      const res = await getDriftReport(activeSymbol);
+      setDriftReport(res.data);
+    } catch { /* handled */ }
+    finally { setDriftLoading(false); }
+  };
+
+  const handleCalibration = async () => {
+    setCalibLoading(true);
+    try {
+      const res = await getCalibration(activeSymbol);
+      setCalibration(res.data);
+    } catch { /* handled */ }
+    finally { setCalibLoading(false); }
   };
 
   if (loading) {
@@ -389,6 +412,144 @@ export default function MLPage() {
                 <p className="text-xs text-muted-foreground text-center py-4">
                   Run a prediction to see the model&apos;s current signal
                 </p>
+              )}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* ─── Step 4: Model Health ─────────────────────────────────── */}
+      {hasModel && (
+        <section className="space-y-3">
+          <div className="flex items-center gap-3">
+            <div className="flex items-center justify-center size-7 rounded-full bg-primary/10 text-primary text-xs font-bold">4</div>
+            <h2 className="text-sm font-bold">Model Health</h2>
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            {/* Drift Panel */}
+            <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Feature Drift (PSI)</h3>
+                <Button onClick={handleDrift} disabled={driftLoading} variant="outline" size="sm" className="h-7 text-xs rounded-lg">
+                  {driftLoading ? <Loader2 className="size-3 mr-1 animate-spin" /> : <Activity className="size-3 mr-1" />}
+                  {driftLoading ? "Checking..." : "Check Drift"}
+                </Button>
+              </div>
+
+              {driftReport && !driftReport.error && (
+                <>
+                  {/* Summary banner */}
+                  <div className={`rounded-lg border px-3 py-2 text-xs font-medium ${
+                    driftReport.alert
+                      ? "border-red-500/30 bg-red-500/5 text-red-400"
+                      : (driftReport.drifted_features as string[])?.length > 0
+                        ? "border-amber-500/30 bg-amber-500/5 text-amber-400"
+                        : "border-green-500/30 bg-green-500/5 text-green-400"
+                  }`}>
+                    {Boolean(driftReport.alert) && <AlertTriangle className="size-3 inline mr-1" />}
+                    {driftReport.summary as string}
+                  </div>
+
+                  {/* PSI bar chart */}
+                  {Object.keys(driftReport.feature_drift as Record<string, number> || {}).length > 0 && (
+                    <div className="h-48">
+                      <ResponsiveContainer width="100%" height="100%">
+                        <BarChart
+                          data={Object.entries(driftReport.feature_drift as Record<string, number>)
+                            .sort(([, a], [, b]) => b - a)
+                            .slice(0, 12)
+                            .map(([name, psi]) => ({ name: name.replace(/_/g, " ").slice(0, 12), psi }))}
+                          layout="vertical"
+                          margin={{ left: 70, right: 10, top: 5, bottom: 5 }}
+                        >
+                          <XAxis type="number" tick={{ fontSize: 10 }} domain={[0, "auto"]} />
+                          <YAxis type="category" dataKey="name" tick={{ fontSize: 10 }} width={65} />
+                          <Tooltip contentStyle={{ fontSize: 11, background: "var(--card)", border: "1px solid var(--border)", borderRadius: 8 }} />
+                          <ReferenceLine x={0.25} stroke="#ef4444" strokeDasharray="3 3" label={{ value: "0.25", fontSize: 9, fill: "#ef4444" }} />
+                          <Bar dataKey="psi" radius={[0, 4, 4, 0]}>
+                            {Object.entries(driftReport.feature_drift as Record<string, number>)
+                              .sort(([, a], [, b]) => b - a)
+                              .slice(0, 12)
+                              .map(([, psi], i) => (
+                                <Cell key={i} fill={psi > 0.25 ? "#ef4444" : psi > 0.1 ? "#f59e0b" : "#22c55e"} />
+                              ))}
+                          </Bar>
+                        </BarChart>
+                      </ResponsiveContainer>
+                    </div>
+                  )}
+
+                  {/* Prediction drift */}
+                  {Object.keys(driftReport.prediction_drift as Record<string, unknown> || {}).length > 0 && (
+                    <div className="space-y-1">
+                      <p className="text-[11px] font-semibold text-muted-foreground uppercase">Prediction Drift</p>
+                      <div className="grid grid-cols-3 gap-2 text-xs">
+                        {Object.entries(driftReport.prediction_drift as Record<string, { expected: number; actual: number; shift: number }>).map(([label, d]) => (
+                          <div key={label} className="rounded-lg border border-border p-2 text-center">
+                            <p className="font-semibold capitalize">{label}</p>
+                            <p className="text-muted-foreground">{(d.expected * 100).toFixed(0)}% → {(d.actual * 100).toFixed(0)}%</p>
+                            <p className={d.shift > 0.05 ? "text-amber-400" : d.shift < -0.05 ? "text-red-400" : "text-green-400"}>
+                              {d.shift > 0 ? "+" : ""}{(d.shift * 100).toFixed(1)}%
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
+              {driftReport && Boolean(driftReport.error) && (
+                <p className="text-xs text-red-400">{String(driftReport.error)}</p>
+              )}
+              {!driftReport && (
+                <p className="text-xs text-muted-foreground text-center py-6">Check drift to compare live features against training distribution</p>
+              )}
+            </div>
+
+            {/* Calibration Panel */}
+            <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Confidence Calibration</h3>
+                <Button onClick={handleCalibration} disabled={calibLoading} variant="outline" size="sm" className="h-7 text-xs rounded-lg">
+                  {calibLoading ? <Loader2 className="size-3 mr-1 animate-spin" /> : <Target className="size-3 mr-1" />}
+                  {calibLoading ? "Loading..." : "Load"}
+                </Button>
+              </div>
+
+              {calibration && !calibration.error && (calibration.buckets as { bucket: string; predicted_confidence: number; actual_win_rate: number; count: number; well_calibrated: boolean }[])?.length > 0 && (
+                <div className="space-y-3">
+                  <div className="h-48">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <BarChart
+                        data={(calibration.buckets as { bucket: string; predicted_confidence: number; actual_win_rate: number; count: number; well_calibrated: boolean }[]).map(b => ({
+                          bucket: b.bucket,
+                          predicted: +(b.predicted_confidence * 100).toFixed(0),
+                          actual: +(b.actual_win_rate * 100).toFixed(0),
+                        }))}
+                        margin={{ left: 5, right: 5, top: 5, bottom: 5 }}
+                      >
+                        <XAxis dataKey="bucket" tick={{ fontSize: 10 }} />
+                        <YAxis tick={{ fontSize: 10 }} domain={[0, 100]} />
+                        <Tooltip contentStyle={{ fontSize: 11, background: "var(--card)", border: "1px solid var(--border)", borderRadius: 8 }} />
+                        <Bar dataKey="predicted" fill="#3b82f6" radius={[4, 4, 0, 0]} name="Predicted %" />
+                        <Bar dataKey="actual" fill="#22c55e" radius={[4, 4, 0, 0]} name="Actual Win %" />
+                      </BarChart>
+                    </ResponsiveContainer>
+                  </div>
+                  <p className="text-[11px] text-muted-foreground text-center">
+                    {calibration.total_predictions as number} predictions | Blue=predicted confidence, Green=actual win rate
+                  </p>
+                </div>
+              )}
+              {calibration && Boolean(calibration.error) && (
+                <p className="text-xs text-red-400">{String(calibration.error)}</p>
+              )}
+              {calibration && !calibration.error && ((calibration.buckets as unknown[])?.length || 0) === 0 && (
+                <p className="text-xs text-muted-foreground text-center py-6">Not enough prediction data yet. Run predictions to build calibration history.</p>
+              )}
+              {!calibration && (
+                <p className="text-xs text-muted-foreground text-center py-6">Load calibration to compare predicted confidence vs actual outcomes</p>
               )}
             </div>
           </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -165,6 +165,18 @@ export const getModelStatus = (symbol?: string) =>
   api.get("/api/ml/status", { params: symbol ? { symbol } : {} });
 export const mlPredict = (symbol?: string) =>
   api.post("/api/ml/predict", null, { params: symbol ? { symbol } : {} });
+export const getDriftReport = (symbol?: string) =>
+  api.get("/api/ml/drift", { params: symbol ? { symbol } : {} });
+export const getCalibration = (symbol?: string) =>
+  api.get("/api/ml/calibration", { params: symbol ? { symbol } : {} });
+
+// Monte Carlo
+export const runMonteCarlo = (params: {
+  strategy: string; symbol?: string; timeframe?: string;
+  n_simulations?: number; initial_balance?: number;
+  source?: string; from_date?: string; to_date?: string;
+  count?: number; params?: Record<string, unknown>;
+}) => api.post("/api/backtest/monte-carlo", params, { timeout: 120000 });
 
 // Macro Data
 export const getMacroLatest = () => api.get("/api/macro/latest");


### PR DESCRIPTION
## Summary
- **Fix broken drift detection**: save per-feature stats during ML training, wire live features into PSI comparison, log predictions for calibration
- **New frontend UI**: drift panel with PSI bar chart + prediction drift on ML page, confidence calibration chart, Monte Carlo simulation tab on backtest page
- **Walk-forward enhancements**: bootstrap 95% CI on OOS Sharpe, parameter stability score (coefficient of variation)

## Changes
| Area | Files | What |
|------|-------|------|
| Backend ML | `trainer.py`, `ml.py` routes | Save feature_stats + label_distribution, log predictions, wire live features to drift |
| Backend Backtest | `walk_forward.py` | `bootstrap_ci()`, `compute_param_stability()`, new result fields |
| Frontend ML | `ml/page.tsx` | Step 4 "Model Health": drift panel (PSI chart, alert banner) + calibration chart |
| Frontend Backtest | `backtest/page.tsx` | Monte Carlo tab (P(Profit), P(Ruin), balance distribution) + CI/stability display |
| Frontend API | `api.ts` | `getDriftReport()`, `getCalibration()`, `runMonteCarlo()` |

## Test plan
- [ ] Backend: `pytest tests/ -v --no-cov` passes (401 tests)
- [ ] Frontend: `npx tsc --noEmit` passes
- [ ] Train ML model → verify `feature_stats` appears in model metrics
- [ ] Run prediction → verify `MLPredictionLog` row created
- [ ] ML page → Check Drift → verify PSI bar chart renders
- [ ] Backtest → Monte Carlo tab → verify simulation results display
- [ ] Walk Forward → verify 95% CI and stability score in verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)