### PR TITLE
Strategy-first architecture + quant strategies + regime engine

### DIFF
--- a/backend/app/api/routes/bot.py
+++ b/backend/app/api/routes/bot.py
@@ -148,9 +148,24 @@ async def get_account():
 
     # Primary balance = first account (MT5) for backward compat
     primary = accounts[0] if accounts else {"balance": 0, "equity": 0, "margin": 0, "free_margin": 0, "profit": 0}
+
+    # Peak balance + drawdown from peak
+    peak_balance = 0.0
+    drawdown_pct = 0.0
+    try:
+        from app.risk.circuit_breaker import CircuitBreaker
+        balance = primary.get("balance", 0)
+        peak_balance = await CircuitBreaker.update_peak_balance(first_engine.redis, balance)
+        if peak_balance > 0:
+            drawdown_pct = (peak_balance - balance) / peak_balance
+    except Exception:
+        pass
+
     return {
         **primary,
         "accounts": accounts,
+        "peak_balance": round(peak_balance, 2),
+        "drawdown_pct": round(drawdown_pct, 4),
     }
 
 

--- a/backend/app/api/routes/history.py
+++ b/backend/app/api/routes/history.py
@@ -59,6 +59,9 @@ async def get_trades(
             "strategy_name": t.strategy_name,
             "ai_sentiment_label": t.ai_sentiment_label,
             "ai_sentiment_score": t.ai_sentiment_score,
+            "trade_reason": t.trade_reason,
+            "pre_trade_snapshot": t.pre_trade_snapshot,
+            "post_trade_analysis": t.post_trade_analysis,
             "source": "bot",
         }
         for t in db_trades

--- a/backend/app/api/routes/strategy.py
+++ b/backend/app/api/routes/strategy.py
@@ -12,12 +12,15 @@ router = APIRouter(prefix="/api/strategy", tags=["strategy"])
 
 @router.get("/available")
 async def get_available_strategies():
-    return {
-        "strategies": [
-            {"name": name, "class": cls.__name__}
-            for name, cls in STRATEGIES.items()
-        ]
-    }
+    strategies = []
+    for name, cls in STRATEGIES.items():
+        try:
+            instance = cls()
+            worst_case = instance.worst_case
+        except Exception:
+            worst_case = ""
+        strategies.append({"name": name, "class": cls.__name__, "worst_case": worst_case})
+    return {"strategies": strategies}
 
 
 @router.get("/current")

--- a/backend/app/bot/engine.py
+++ b/backend/app/bot/engine.py
@@ -6,7 +6,7 @@ import enum
 import json
 import random
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from app.constants import (
     BREAKEVEN_ATR_MULT,
@@ -146,6 +146,12 @@ class BotEngine:
         # Lot sizing mode: None = auto (AI/Kelly/risk-based), float = fixed lot
         self.fixed_lot: float | None = None
 
+        # Regime-aware risk + event filter
+        from app.data.macro_events import MacroEventCalendar
+        self._event_calendar = MacroEventCalendar()
+        self._last_regime = "normal"
+        self._multi_tf_regime = None  # MultiTFRegime, set in process_candle
+
         # Paper trade mode
         self.paper_trade = settings.paper_trade
         self._paper_positions: list[dict] = []
@@ -227,7 +233,7 @@ class BotEngine:
         sentiment = getattr(self, "_last_sentiment", None)
         return {
             "state": self.state.value,
-            "strategy": "ai_autonomous",
+            "strategy": self.strategy.name if self.strategy else "ai_autonomous",
             "strategy_params": {},
             "symbol": self.symbol,
             "timeframe": self.timeframe,
@@ -239,6 +245,8 @@ class BotEngine:
             "max_concurrent_trades": self.risk_manager.max_concurrent_trades,
             "max_lot": self.risk_manager.max_lot,
             "fixed_lot": self.fixed_lot,
+            "regime": self._last_regime,
+            "multi_tf_regime": self._multi_tf_regime.to_dict() if self._multi_tf_regime else None,
             "ai_decision": ai_decision,
             "sentiment": sentiment,
         }
@@ -265,8 +273,28 @@ class BotEngine:
                 return
             balance = account["data"]["balance"]
 
+            # Track peak balance for absolute drawdown detection
+            await CircuitBreaker.update_peak_balance(self.redis, balance)
+
             if await self._check_circuit_breakers(balance):
                 return
+
+            # 1b. Multi-timeframe regime detection
+            try:
+                from app.strategy.regime import detect_multi_tf_regime
+                self._multi_tf_regime = await detect_multi_tf_regime(self.market_data, self.symbol)
+                self.risk_manager.set_regime(self._multi_tf_regime.composite)
+                self._last_regime = self._multi_tf_regime.composite
+                # Cache for dashboard
+                await self.redis.setex(f"mtf_regime:{self.symbol}", 300, json.dumps(self._multi_tf_regime.to_dict()))
+            except Exception as e:
+                logger.warning(f"Multi-TF regime detection failed: {e}")
+
+            # 1c. Check macro event proximity — reduce exposure or skip
+            from app.constants import EVENT_BLOCK_HOURS
+            near_event = self._event_calendar.is_near_event(hours_before=EVENT_BLOCK_HOURS)
+            if near_event:
+                logger.info(f"Near macro event [{self.symbol}]: {near_event.get('event', 'unknown')} — reducing exposure")
 
             # 2. Generate trading signal
             result = await self._generate_signal()
@@ -281,7 +309,7 @@ class BotEngine:
                 return
 
             # 4. Size position and place order
-            await self._size_and_place_order(signal, signal_label, df, balance, ai_sentiment)
+            await self._size_and_place_order(signal, signal_label, df, balance, ai_sentiment, near_event=near_event)
 
         except Exception as e:
             logger.error(f"Bot engine error: {e}")
@@ -314,6 +342,19 @@ class BotEngine:
                 await self._notify(self.notifier.send_error_alert("⚡ Portfolio circuit breaker — ALL symbols paused"))
             return True
 
+        # Absolute drawdown from peak balance
+        drawdown_halted = await CircuitBreaker.is_drawdown_halted(
+            self.redis, balance, settings.max_drawdown_from_peak,
+        )
+        if drawdown_halted:
+            self.state = BotState.PAUSED
+            await self._log_event(BotEventType.CIRCUIT_BREAKER, "Absolute drawdown limit reached — trading halted")
+            if self.notifier:
+                await self._notify(self.notifier.send_error_alert(
+                    f"🛑 DRAWDOWN HALT: Balance dropped >{settings.max_drawdown_from_peak:.0%} from peak"
+                ))
+            return True
+
         return False
 
     async def _generate_signal(self) -> tuple[int, str, "pd.DataFrame"] | None:
@@ -325,6 +366,10 @@ class BotEngine:
         # Lazy-load ML model from DB if strategy supports it
         if hasattr(self.strategy, "_ensure_model"):
             await self.strategy._ensure_model()
+
+        # Fetch cross-symbol data for quant strategies (risk parity, momentum rank, pair spread)
+        if hasattr(self.strategy, "_prepare_cross_data"):
+            await self.strategy._prepare_cross_data(self.market_data)
 
         df = self.strategy.calculate(df)
         if len(df) < 2:
@@ -381,6 +426,46 @@ class BotEngine:
         if self._ai_context:
             trade_patterns = self.context_builder.get_trade_patterns_for_risk(self._ai_context)
 
+        # Adaptive confidence: compute effective threshold
+        eff_threshold = None
+        try:
+            from app.config import SESSION_PROFILES
+            current_hour = datetime.now(timezone.utc).hour
+            session_boost = 0.0
+            for prof in SESSION_PROFILES.values():
+                h_start, h_end = prof["hours"]
+                if h_start <= current_hour < h_end:
+                    session_boost = prof.get("confidence_boost", 0.0)
+                    break
+
+            # Recent win rate
+            recent_wr = None
+            from app.constants import CONFIDENCE_RECENT_TRADES_WINDOW
+            from sqlalchemy import select as _sel2
+            stmt = (_sel2(Trade).where(Trade.symbol == self.symbol, Trade.profit.isnot(None))
+                    .order_by(Trade.id.desc()).limit(CONFIDENCE_RECENT_TRADES_WINDOW))
+            result = await self.db.execute(stmt)
+            recent = result.scalars().all()
+            if len(recent) >= 10:
+                recent_wr = sum(1 for t in recent if t.profit > 0) / len(recent)
+
+            # Drawdown
+            dd_pct = 0.0
+            peak_raw = await self.redis.get("circuit:peak_balance")
+            if peak_raw and balance > 0:
+                peak = float(peak_raw)
+                if peak > 0:
+                    dd_pct = (peak - balance) / peak
+
+            regime = self._multi_tf_regime.composite if self._multi_tf_regime else self._last_regime
+            eff_threshold = self.risk_manager.compute_effective_confidence(
+                session_boost=session_boost, regime=regime,
+                recent_win_rate=recent_wr, drawdown_pct=dd_pct,
+            )
+            self._last_effective_threshold = eff_threshold
+        except Exception:
+            pass
+
         can_trade, reason = self.risk_manager.can_open_trade(
             current_positions=len(positions),
             daily_pnl=daily_pnl,
@@ -388,6 +473,7 @@ class BotEngine:
             signal=signal,
             ai_sentiment=ai_sentiment,
             trade_patterns=trade_patterns,
+            effective_threshold=eff_threshold,
         )
         if not can_trade:
             logger.info(f"Trade blocked: {reason}")
@@ -421,6 +507,7 @@ class BotEngine:
 
     async def _size_and_place_order(
         self, signal: int, signal_label: str, df, balance: float, ai_sentiment: dict | None,
+        near_event: dict | None = None,
     ) -> None:
         """Calculate lot size, apply adjustments, and place order (real or paper)."""
         atr = df.iloc[-2].get("atr", DEFAULT_ATR_FALLBACK)
@@ -429,9 +516,25 @@ class BotEngine:
             return
 
         entry_price = tick["ask"] if signal == 1 else tick["bid"]
+        atr_pct = atr / entry_price if entry_price > 0 else 0
+
+        # Detect regime and apply to risk manager
+        from app.strategy.regime import detect_regime as _detect_regime
+        adx_value = df.iloc[-2].get("adx", 20)
+        regime = _detect_regime(atr_pct, adx_value)
+        self.risk_manager.set_regime(regime)
+
+        # Notify on regime change
+        if regime != self._last_regime:
+            old_regime = self._last_regime
+            self._last_regime = regime
+            await self._log_event(BotEventType.SIGNAL_DETECTED, f"Regime: {old_regime} → {regime}")
+            if self.notifier:
+                import asyncio as _asyncio
+                _asyncio.create_task(self.notifier.send_regime_change(self.symbol, old_regime, regime))
+
         sl_tp = self.risk_manager.calculate_sl_tp(entry_price, signal, atr)
         sl_pips = abs(entry_price - sl_tp.sl)
-        atr_pct = atr / entry_price if entry_price > 0 else 0
 
         # Position sizing: fixed lot or AI-calculated (Kelly/risk-based)
         if self.fixed_lot is not None:
@@ -443,6 +546,13 @@ class BotEngine:
             lot = self._apply_warmup(lot)
             # Apply consecutive loss streak reduction
             lot = await self._apply_streak_adjustment(lot)
+
+        # Event filter: reduce lot near high-impact events
+        if near_event:
+            from app.constants import EVENT_LOT_FACTOR
+            lot = round(lot * EVENT_LOT_FACTOR, 2)
+            lot = max(lot, MIN_LOT)
+            logger.info(f"Event filter [{self.symbol}]: lot reduced to {lot} (event: {near_event.get('event', 'unknown')})")
 
         # Place order (real or paper)
         order_type = "BUY" if signal == 1 else "SELL"
@@ -482,6 +592,25 @@ class BotEngine:
         if slippage_price > 0:
             logger.info(f"Slippage [{self.symbol}]: expected={entry_price}, fill={actual_fill}, diff={slippage_price:.{self.risk_manager.price_decimals}f}")
 
+        # Pre-trade snapshot — complete decision context for tracing
+        snapshot = {
+            "balance": balance,
+            "regime": self._multi_tf_regime.to_dict() if self._multi_tf_regime else {"composite": self._last_regime},
+            "indicators": {
+                "atr": round(atr, 4),
+                "atr_pct": round(atr_pct, 6),
+                "adx": round(float(df.iloc[-2].get("adx", 0)), 2) if "adx" in df.columns else None,
+            },
+            "risk": {
+                "effective_confidence": getattr(self, "_last_effective_threshold", None),
+                "lot_final": lot,
+                "near_event": bool(near_event),
+            },
+            "ai_sentiment": ai_sentiment,
+            "strategy": self.strategy.name,
+            "strategy_reason": self.strategy.last_reason,
+        }
+
         trade = Trade(
             ticket=result["data"]["ticket"],
             symbol=self.symbol,
@@ -495,6 +624,8 @@ class BotEngine:
             strategy_name=self.strategy.name,
             ai_sentiment_score=sentiment_data.get("confidence"),
             ai_sentiment_label=sentiment_data.get("label"),
+            trade_reason=self.strategy.last_reason or None,
+            pre_trade_snapshot=snapshot,
         )
         await self._save_trade(trade)
 
@@ -552,6 +683,12 @@ class BotEngine:
             if consecutive_losses >= 2:
                 lot = self.risk_manager.adjust_for_streak(lot, consecutive_losses, 0)
                 logger.info(f"Loss streak [{self.symbol}]: {consecutive_losses} consecutive → lot={lot}")
+                # Alert on significant losing streak
+                from app.constants import LOSING_STREAK_ALERT_THRESHOLD
+                if consecutive_losses >= LOSING_STREAK_ALERT_THRESHOLD and self.notifier:
+                    factor = STREAK_3_FACTOR if consecutive_losses >= 3 else STREAK_2_FACTOR
+                    import asyncio as _asyncio
+                    _asyncio.create_task(self.notifier.send_losing_streak_alert(self.symbol, consecutive_losses, factor))
         except Exception:
             pass
         return lot
@@ -679,6 +816,9 @@ class BotEngine:
                 trade.close_price = close_price
                 trade.close_time = close_time
                 trade.profit = profit
+                # Post-trade analysis
+                analysis = self._build_post_trade_analysis(trade, deal, self._multi_tf_regime)
+                trade.post_trade_analysis = analysis
                 await self.db.commit()
 
             # Log event
@@ -695,12 +835,101 @@ class BotEngine:
                 "profit": profit,
             })
 
-            # Telegram notification
+            # Telegram notification (enhanced with analysis)
             if self.notifier:
-                await self._notify(self.notifier.send_trade_alert(
-                    "CLOSE", self.symbol, close_price, 0, 0, deal.get("lot", 0) if deal else 0,
-                    extra=profit_str,
+                if trade and trade.post_trade_analysis:
+                    await self._notify(self.notifier.send_trade_close_with_analysis(
+                        self.symbol, close_price, deal.get("lot", 0) if deal else 0,
+                        profit, trade.post_trade_analysis,
+                    ))
+                else:
+                    await self._notify(self.notifier.send_trade_alert(
+                        "CLOSE", self.symbol, close_price, 0, 0, deal.get("lot", 0) if deal else 0,
+                        extra=profit_str,
+                    ))
+
+            # ML prediction feedback: link closed trade outcome to recent prediction
+            await self._update_prediction_feedback(profit)
+
+    @staticmethod
+    def _build_post_trade_analysis(trade, deal: dict | None, mtf_regime) -> dict:
+        """Generate post-trade analysis: exit reason, duration, outcome summary."""
+        exit_reason = "unknown"
+        if trade.close_price and trade.sl and trade.tp:
+            sl_dist = abs(trade.close_price - trade.sl)
+            tp_dist = abs(trade.close_price - trade.tp)
+            entry_to_sl = abs(trade.open_price - trade.sl) or 1
+            entry_to_tp = abs(trade.open_price - trade.tp) or 1
+            if sl_dist < entry_to_sl * 0.2:
+                exit_reason = "stop_loss"
+            elif tp_dist < entry_to_tp * 0.2:
+                exit_reason = "take_profit"
+            else:
+                exit_reason = "manual_close"
+
+        duration_hours = None
+        if trade.open_time and trade.close_time:
+            delta = trade.close_time - trade.open_time
+            duration_hours = round(delta.total_seconds() / 3600, 2)
+
+        profit = trade.profit or 0
+        outcome = "win" if profit > 0 else ("breakeven" if profit == 0 else "loss")
+
+        parts = []
+        if exit_reason == "stop_loss":
+            parts.append("SL ถูกชน")
+        elif exit_reason == "take_profit":
+            parts.append("ถึง TP สำเร็จ")
+        else:
+            parts.append("ปิดด้วยตนเอง/ระบบ")
+        if duration_hours is not None:
+            parts.append(f"ถือ {int(duration_hours * 60)} นาที" if duration_hours < 1 else f"ถือ {duration_hours:.1f} ชม.")
+
+        snap = trade.pre_trade_snapshot or {}
+        entry_regime = snap.get("regime", {}).get("composite", "unknown")
+
+        return {
+            "exit_reason": exit_reason,
+            "duration_hours": duration_hours,
+            "outcome": outcome,
+            "profit_usd": round(profit, 2),
+            "entry_regime": entry_regime,
+            "exit_regime": mtf_regime.composite if mtf_regime else None,
+            "summary_th": " | ".join(parts),
+        }
+
+    async def _update_prediction_feedback(self, profit: float) -> None:
+        """Find matching MLPredictionLog and set was_correct + actual_outcome."""
+        try:
+            from app.db.models import MLPredictionLog
+            from app.constants import PREDICTION_FEEDBACK_HOURS
+            from sqlalchemy import select, and_
+            cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=PREDICTION_FEEDBACK_HOURS)
+            stmt = (
+                select(MLPredictionLog)
+                .where(and_(
+                    MLPredictionLog.symbol == self.symbol,
+                    MLPredictionLog.was_correct.is_(None),
+                    MLPredictionLog.created_at >= cutoff,
                 ))
+                .order_by(MLPredictionLog.created_at.desc())
+                .limit(1)
+            )
+            result = await self.db.execute(stmt)
+            pred = result.scalar_one_or_none()
+            if pred:
+                actual = 1 if profit > 0 else -1
+                pred.actual_outcome = actual
+                # BUY prediction (+1) correct if profit > 0, SELL (-1) correct if profit > 0
+                pred.was_correct = (pred.predicted_signal == actual) or (pred.predicted_signal == 0 and abs(profit) < 1)
+                await self.db.commit()
+                logger.info(f"ML feedback [{self.symbol}]: prediction={pred.predicted_signal}, outcome={actual}, correct={pred.was_correct}")
+        except Exception as e:
+            try:
+                await self.db.rollback()
+            except Exception:
+                pass
+            logger.warning(f"ML feedback update failed: {e}")
 
     async def _sync_paper_positions(self) -> list[dict]:
         """Update paper positions with current prices, close if SL/TP hit."""

--- a/backend/app/bot/scheduler.py
+++ b/backend/app/bot/scheduler.py
@@ -10,6 +10,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from loguru import logger
 
 from app.bot.engine import BotEngine
+from app.config import settings
 
 # Timeframe → cron schedule mapping
 TIMEFRAME_CRON = {
@@ -179,6 +180,16 @@ class BotScheduler:
             coalesce=True,
         )
 
+        # Daily trading summary: 22:00 UTC (forex market close)
+        self.scheduler.add_job(
+            self._daily_summary_job,
+            "cron",
+            hour=22,
+            minute=0,
+            id="daily_summary",
+            max_instances=1,
+        )
+
         self.scheduler.start()
         logger.info("Scheduler started")
 
@@ -241,8 +252,23 @@ class BotScheduler:
 
     async def _candle_job(self, symbols: list[str]):
         logger.debug(f"Candle job triggered for {symbols}")
-        # AI Agent is the primary decision-maker (no rule-based strategies)
-        await self._run_ai_agent(symbols)
+
+        trading_mode = getattr(settings, "trading_mode", "strategy")
+
+        if trading_mode == "strategy":
+            # Strategy-first: rule-based strategies generate signals, AI is filter only
+            for sym in symbols:
+                engine = self._engines.get(sym)
+                if engine and engine.state.value == "RUNNING":
+                    try:
+                        await engine.process_candle()
+                    except Exception as e:
+                        logger.error(f"process_candle error [{sym}]: {e}")
+            # AI analysis in parallel (for dashboard display, not trading)
+            asyncio.create_task(self._run_ai_agent(symbols))
+        else:
+            # AI autonomous: AI agent is the primary decision-maker
+            await self._run_ai_agent(symbols)
 
     async def _sentiment_job(self):
         """Fetch news sentiment regardless of bot state — news comes out 24/7.
@@ -356,6 +382,53 @@ class BotScheduler:
         logger.info("Daily reset triggered")
         tasks = [e.circuit_breaker.reset() for e in self._engines.values()]
         await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _daily_summary_job(self):
+        """Daily trading summary at market close — sends Telegram report."""
+        logger.info("Daily summary triggered")
+        try:
+            from sqlalchemy import select, and_, func
+            from app.db.models import Trade
+            from datetime import datetime, timezone, timedelta
+
+            symbol_stats = []
+            total_pnl = 0.0
+            total_trades = 0
+            total_wins = 0
+
+            for symbol, engine in self._engines.items():
+                # Get today's closed trades
+                today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=None)
+                stmt = select(Trade).where(and_(
+                    Trade.symbol == symbol,
+                    Trade.close_time >= today_start,
+                    Trade.profit.isnot(None),
+                ))
+                result = await engine.db.execute(stmt)
+                trades = result.scalars().all()
+
+                pnl = sum(t.profit for t in trades)
+                wins = sum(1 for t in trades if t.profit > 0)
+                total_pnl += pnl
+                total_trades += len(trades)
+                total_wins += wins
+
+                symbol_stats.append({
+                    "symbol": symbol,
+                    "pnl": round(pnl, 2),
+                    "trades": len(trades),
+                    "regime": engine.risk_manager.current_regime,
+                })
+
+            total_win_rate = total_wins / total_trades if total_trades > 0 else 0
+
+            # Send via first engine's notifier
+            notifier = next((e.notifier for e in self._engines.values() if e.notifier), None)
+            if notifier:
+                await notifier.send_daily_summary(symbol_stats, round(total_pnl, 2), total_trades, total_win_rate)
+                logger.info(f"Daily summary sent: PnL=${total_pnl:.2f}, trades={total_trades}")
+        except Exception as e:
+            logger.error(f"Daily summary failed: {e}")
 
     async def _ml_retrain_job(self):
         """Weekly ML retrain — trains per-symbol on last 6 months of data."""

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -118,6 +118,7 @@ class Settings(BaseSettings):
     max_daily_loss: float = 0.03
     max_concurrent_trades: int = 3
     max_lot: float = 1.0
+    max_drawdown_from_peak: float = 0.15  # 15% absolute drawdown → halt
     use_ai_filter: bool = True
     ai_confidence_threshold: float = 0.7
     paper_trade: bool = False
@@ -172,6 +173,7 @@ class Settings(BaseSettings):
 
     # Agent
     agent_mode: str = "single"  # "single" (Phase C) or "multi" (Phase D: orchestrator + specialists)
+    trading_mode: str = "strategy"  # "strategy" (strategy-first, AI filter) | "ai_autonomous" (AI decides)
     rollout_mode: str = "shadow"  # "shadow" | "paper" | "micro" | "live" (Phase F gradual rollout)
 
     # Logging

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -107,3 +107,36 @@ MIN_TTL_SECONDS = 60  # minimum Redis TTL for daily PnL keys
 KELLY_RECENT_TRADES = 50
 # Streak detection: recent trades to check
 STREAK_RECENT_TRADES = 5
+
+# ─── Regime-Aware Risk ──────────────────────────────────────────────────────
+
+REGIME_LOT_MULTIPLIERS = {
+    "trending_high_vol": 0.7,
+    "trending_low_vol": 1.0,
+    "ranging": 0.5,
+    "normal": 1.0,
+}
+
+# ─── Event Filter ───────────────────────────────────────────────────────────
+
+EVENT_LOT_FACTOR = 0.5       # halve lot size near high-impact events
+EVENT_BLOCK_HOURS = 2        # hours before event to reduce exposure
+
+# ─── Notifications ──────────────────────────────────────────────────────────
+
+LOSING_STREAK_ALERT_THRESHOLD = 3  # consecutive losses before Telegram alert
+PREDICTION_FEEDBACK_HOURS = 4      # match predictions within N hours of trade close
+
+# ─── Absolute Drawdown ──────────────────────────────────────────────────────
+
+DEFAULT_MAX_DRAWDOWN_FROM_PEAK = 0.15  # 15% drawdown from peak → halt all trading
+
+# ─── Adaptive Confidence Policy ─────────────────────────────────────────────
+
+CONFIDENCE_DRAWDOWN_5_BOOST = 0.05     # stricter when drawdown > 5%
+CONFIDENCE_DRAWDOWN_10_BOOST = 0.10    # much stricter when drawdown > 10%
+CONFIDENCE_RANGING_BOOST = 0.05        # stricter in ranging (false signals common)
+CONFIDENCE_TRENDING_HV_DISCOUNT = 0.05 # looser in clear high-vol trend
+CONFIDENCE_LOW_WINRATE_BOOST = 0.10    # stricter when recent win rate < 40%
+CONFIDENCE_LOW_WINRATE_THRESHOLD = 0.40
+CONFIDENCE_RECENT_TRADES_WINDOW = 20

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -127,6 +127,9 @@ class Trade(Base):
     strategy_name: Mapped[str] = mapped_column(String(50))
     ai_sentiment_score: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     ai_sentiment_label: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
+    trade_reason: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    pre_trade_snapshot: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+    post_trade_analysis: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now()
     )

--- a/backend/app/notifications/telegram.py
+++ b/backend/app/notifications/telegram.py
@@ -124,3 +124,50 @@ class TelegramNotifier:
     async def send_stop_alert(self, symbol: str = ""):
         sym_name = f" {self._sym(symbol)}" if symbol else ""
         await self._send(f"⏹ <b>หยุดเทรด{sym_name}</b>")
+
+    async def send_daily_summary(self, symbol_stats: list[dict], total_pnl: float, total_trades: int, total_win_rate: float):
+        icon = "📈" if total_pnl >= 0 else "📉"
+        lines = [
+            f"{icon} <b>สรุปประจำวัน</b>",
+            f"💰 P&L: <b>${total_pnl:+.2f}</b>  |  เทรด: {total_trades}  |  ชนะ: {total_win_rate:.0%}",
+            "",
+        ]
+        for s in symbol_stats:
+            regime_icon = {"trending_high_vol": "🔥", "trending_low_vol": "📊", "ranging": "↔️", "normal": "⚖️"}.get(s.get("regime", ""), "⚖️")
+            pnl_str = f"${s['pnl']:+.2f}" if s.get("pnl") is not None else "—"
+            lines.append(f"{regime_icon} {self._sym(s['symbol'])}: {pnl_str} ({s.get('trades', 0)} trades, regime: {s.get('regime', 'unknown')})")
+        await self._send("\n".join(lines))
+
+    async def send_losing_streak_alert(self, symbol: str, count: int, lot_factor: float):
+        sym_name = self._sym(symbol)
+        lines = [
+            "🔴 <b>แจ้งเตือนขาดทุนติดต่อกัน</b>",
+            f"📉 {sym_name}: ขาดทุน <b>{count} ครั้งติด</b>",
+            f"⚙️ ปรับลด lot เหลือ {lot_factor:.0%} อัตโนมัติ",
+        ]
+        await self._send("\n".join(lines))
+
+    async def send_trade_close_with_analysis(self, symbol: str, close_price: float, lot: float, profit: float, analysis: dict):
+        icon = "📈" if profit >= 0 else "📉"
+        outcome = "กำไร" if profit >= 0 else "ขาดทุน"
+        summary = analysis.get("summary_th", "")
+        exit_map = {"stop_loss": "🛑 SL", "take_profit": "🎯 TP", "manual_close": "👤 Manual"}
+        exit_label = exit_map.get(analysis.get("exit_reason", ""), "❓")
+        lines = [
+            f"🏁 <b>ปิดสถานะ {self._sym(symbol)}</b>",
+            f"💰 ราคา: {close_price:.2f}  |  Lot: {lot}",
+            f"{icon} {outcome}: <b>${abs(profit):.2f}</b>",
+            f"📋 {exit_label} | {summary}",
+        ]
+        if analysis.get("entry_regime"):
+            lines.append(f"📊 Regime: {analysis['entry_regime']} → {analysis.get('exit_regime', '?')}")
+        await self._send("\n".join(lines))
+
+    async def send_regime_change(self, symbol: str, old_regime: str, new_regime: str):
+        sym_name = self._sym(symbol)
+        regime_th = {"trending_high_vol": "เทรนด์+ผันผวนสูง 🔥", "trending_low_vol": "เทรนด์+ผันผวนต่ำ", "ranging": "ไซด์เวย์ ↔️", "normal": "ปกติ ⚖️"}
+        lines = [
+            "🔄 <b>Regime เปลี่ยน</b>",
+            f"📊 {sym_name}: {regime_th.get(old_regime, old_regime)} → {regime_th.get(new_regime, new_regime)}",
+        ]
+        await self._send("\n".join(lines))

--- a/backend/app/risk/circuit_breaker.py
+++ b/backend/app/risk/circuit_breaker.py
@@ -10,7 +10,7 @@ import redis.asyncio as redis
 from loguru import logger
 
 from app.config import settings
-from app.constants import DEFAULT_PORTFOLIO_MAX_LOSS, MIN_TTL_SECONDS
+from app.constants import DEFAULT_MAX_DRAWDOWN_FROM_PEAK, DEFAULT_PORTFOLIO_MAX_LOSS, MIN_TTL_SECONDS
 
 # Market hours reset time (UTC) per symbol type
 # Forex/metals reset at 17:00 EST = 22:00 UTC (21:00 during DST)
@@ -126,6 +126,35 @@ class CircuitBreaker:
         if triggered:
             logger.warning(f"GLOBAL circuit breaker TRIGGERED: total_pnl={total_pnl:.2f}, limit=-{max_loss:.2f}")
         return triggered
+
+    @staticmethod
+    async def update_peak_balance(redis_client, balance: float) -> float:
+        """Track peak balance in Redis (no TTL — persists across restarts)."""
+        key = "circuit:peak_balance"
+        current = await redis_client.get(key)
+        peak = float(current) if current else 0.0
+        if balance > peak:
+            peak = balance
+            await redis_client.set(key, str(peak))
+        return peak
+
+    @staticmethod
+    async def is_drawdown_halted(
+        redis_client, balance: float,
+        max_drawdown_pct: float = DEFAULT_MAX_DRAWDOWN_FROM_PEAK,
+    ) -> bool:
+        """Check if balance dropped > X% from peak. Returns True to halt trading."""
+        peak = await CircuitBreaker.update_peak_balance(redis_client, balance)
+        if peak <= 0:
+            return False
+        drawdown_pct = (peak - balance) / peak
+        if drawdown_pct >= max_drawdown_pct:
+            logger.warning(
+                f"ABSOLUTE DRAWDOWN HALT: balance={balance:.2f}, peak={peak:.2f}, "
+                f"drawdown={drawdown_pct:.1%} >= limit={max_drawdown_pct:.1%}"
+            )
+            return True
+        return False
 
     @staticmethod
     def _seconds_until_reset(symbol: str) -> int:

--- a/backend/app/risk/manager.py
+++ b/backend/app/risk/manager.py
@@ -16,6 +16,7 @@ from app.constants import (
     LOW_VOL_LOT_FACTOR,
     LOW_VOL_THRESHOLD,
     MIN_LOT,
+    REGIME_LOT_MULTIPLIERS,
     STREAK_2_FACTOR,
     STREAK_3_FACTOR,
     AI_MAX_THRESHOLD,
@@ -53,6 +54,17 @@ class RiskManager:
         self.price_decimals = price_decimals
         self.sl_atr_mult = sl_atr_mult
         self.tp_atr_mult = tp_atr_mult
+        # Regime-aware risk
+        self.current_regime = "normal"
+        self.regime_lot_multiplier = 1.0
+
+    def set_regime(self, regime: str) -> None:
+        """Update current regime and apply corresponding lot multiplier."""
+        old = self.current_regime
+        self.current_regime = regime
+        self.regime_lot_multiplier = REGIME_LOT_MULTIPLIERS.get(regime, 1.0)
+        if old != regime:
+            logger.info(f"Regime changed: {old} → {regime} (lot mult: {self.regime_lot_multiplier})")
 
     def calculate_lot_size(
         self, balance: float, sl_pips: float, pip_value: float | None = None,
@@ -77,6 +89,9 @@ class RiskManager:
                 lot *= HIGH_VOL_LOT_FACTOR
             elif atr_pct < LOW_VOL_THRESHOLD:
                 lot *= LOW_VOL_LOT_FACTOR
+
+        # Regime adjustment
+        lot *= self.regime_lot_multiplier
 
         lot = round(min(lot, self.max_lot), 2)
         return max(lot, MIN_LOT)
@@ -119,8 +134,13 @@ class RiskManager:
         self, entry_price: float, signal: int, atr: float,
         sl_mult: float | None = None, tp_mult: float | None = None,
     ) -> SLTPResult:
+        from app.strategy.regime import REGIME_ADJUSTMENTS
         sl_m = sl_mult if sl_mult is not None else self.sl_atr_mult
         tp_m = tp_mult if tp_mult is not None else self.tp_atr_mult
+        # Apply regime SL/TP adjustments
+        adj = REGIME_ADJUSTMENTS.get(self.current_regime, {})
+        sl_m *= adj.get("sl_atr_mult_factor", 1.0)
+        tp_m *= adj.get("tp_atr_mult_factor", 1.0)
         if signal == 1:  # BUY
             sl = entry_price - (atr * sl_m)
             tp = entry_price + (atr * tp_m)
@@ -132,6 +152,42 @@ class RiskManager:
             tp=round(tp, self.price_decimals),
         )
 
+    def compute_effective_confidence(
+        self,
+        session_boost: float = 0.0,
+        regime: str = "normal",
+        recent_win_rate: float | None = None,
+        drawdown_pct: float = 0.0,
+    ) -> float:
+        """Dynamic confidence threshold based on market conditions + performance."""
+        from app.constants import (
+            CONFIDENCE_DRAWDOWN_5_BOOST,
+            CONFIDENCE_DRAWDOWN_10_BOOST,
+            CONFIDENCE_RANGING_BOOST,
+            CONFIDENCE_TRENDING_HV_DISCOUNT,
+            CONFIDENCE_LOW_WINRATE_BOOST,
+            CONFIDENCE_LOW_WINRATE_THRESHOLD,
+        )
+        threshold = self.ai_confidence_threshold + session_boost
+
+        # Drawdown-based tightening
+        if drawdown_pct > 0.10:
+            threshold += CONFIDENCE_DRAWDOWN_10_BOOST
+        elif drawdown_pct > 0.05:
+            threshold += CONFIDENCE_DRAWDOWN_5_BOOST
+
+        # Regime adjustment
+        if regime == "ranging":
+            threshold += CONFIDENCE_RANGING_BOOST
+        elif regime == "trending_high_vol":
+            threshold -= CONFIDENCE_TRENDING_HV_DISCOUNT
+
+        # Recent performance
+        if recent_win_rate is not None and recent_win_rate < CONFIDENCE_LOW_WINRATE_THRESHOLD:
+            threshold += CONFIDENCE_LOW_WINRATE_BOOST
+
+        return min(max(threshold, self.ai_confidence_threshold * 0.8), AI_MAX_THRESHOLD)
+
     def can_open_trade(
         self,
         current_positions: int,
@@ -140,6 +196,7 @@ class RiskManager:
         signal: int = 0,
         ai_sentiment: dict | None = None,
         trade_patterns: dict | None = None,
+        effective_threshold: float | None = None,
     ) -> tuple[bool, str]:
         # Check max concurrent trades
         if current_positions >= self.max_concurrent_trades:
@@ -150,21 +207,24 @@ class RiskManager:
         if daily_pnl <= -max_loss:
             return False, f"Daily loss limit reached ({daily_pnl:.2f} <= -{max_loss:.2f})"
 
-        # Adjust confidence threshold based on trade patterns
-        effective_threshold = self.ai_confidence_threshold
-        if trade_patterns:
-            from datetime import datetime, timezone
-            current_hour = datetime.now(timezone.utc).hour
-            worst_hours = trade_patterns.get("worst_hours", [])
-            if current_hour in worst_hours:
-                effective_threshold = min(effective_threshold + AI_WORST_HOUR_THRESHOLD_BOOST, AI_MAX_THRESHOLD)
+        # Use adaptive threshold if provided, otherwise fallback to existing logic
+        if effective_threshold is not None:
+            eff_threshold = effective_threshold
+        else:
+            eff_threshold = self.ai_confidence_threshold
+            if trade_patterns:
+                from datetime import datetime, timezone
+                current_hour = datetime.now(timezone.utc).hour
+                worst_hours = trade_patterns.get("worst_hours", [])
+                if current_hour in worst_hours:
+                    eff_threshold = min(eff_threshold + AI_WORST_HOUR_THRESHOLD_BOOST, AI_MAX_THRESHOLD)
 
         # AI sentiment filter (optional)
         if self.use_ai_filter and ai_sentiment and signal != 0:
             confidence = ai_sentiment.get("confidence", 0)
             label = ai_sentiment.get("label", "neutral")
 
-            if confidence >= effective_threshold:
+            if confidence >= eff_threshold:
                 if signal == 1 and label == "bearish":
                     return False, f"AI sentiment bearish (confidence: {confidence:.0%}) — BUY signal filtered"
                 if signal == -1 and label == "bullish":

--- a/backend/app/strategy/__init__.py
+++ b/backend/app/strategy/__init__.py
@@ -2,8 +2,13 @@ from pathlib import Path
 
 from app.strategy.base import BaseStrategy
 from app.strategy.breakout import BreakoutStrategy
+from app.strategy.dca import DCAStrategy
 from app.strategy.ema_crossover import EMACrossoverStrategy
+from app.strategy.grid import GridStrategy
 from app.strategy.mean_reversion import MeanReversionStrategy
+from app.strategy.momentum_rank import MomentumRankStrategy
+from app.strategy.pair_spread import PairSpreadStrategy
+from app.strategy.risk_parity import RiskParityStrategy
 from app.strategy.rsi_filter import RSIFilterStrategy
 
 STRATEGIES: dict[str, type[BaseStrategy]] = {
@@ -11,6 +16,11 @@ STRATEGIES: dict[str, type[BaseStrategy]] = {
     "rsi_filter": RSIFilterStrategy,
     "breakout": BreakoutStrategy,
     "mean_reversion": MeanReversionStrategy,
+    "dca": DCAStrategy,
+    "grid": GridStrategy,
+    "risk_parity": RiskParityStrategy,
+    "momentum_rank": MomentumRankStrategy,
+    "pair_spread": PairSpreadStrategy,
 }
 
 # Conditionally register ML strategy if model exists
@@ -30,8 +40,8 @@ def get_strategy(name: str, params: dict | None = None, symbol: str = "GOLD") ->
     if cls is None:
         raise ValueError(f"Unknown strategy: {name}. Available: {list(STRATEGIES.keys())}")
     kwargs = dict(params or {})
-    # Pass symbol to ML strategy for per-symbol model loading
-    if name == "ml_signal":
+    # Pass symbol to strategies that need it (ML + quant cross-asset)
+    if name in ("ml_signal", "risk_parity", "momentum_rank", "pair_spread"):
         kwargs.setdefault("symbol", symbol)
     return cls(**kwargs)
 

--- a/backend/app/strategy/base.py
+++ b/backend/app/strategy/base.py
@@ -8,6 +8,9 @@ import pandas as pd
 
 
 class BaseStrategy(ABC):
+    # Class-level default — subclasses set via self._last_reason in calculate()
+    _last_reason: str = ""
+
     @property
     @abstractmethod
     def name(self) -> str:
@@ -17,6 +20,17 @@ class BaseStrategy(ABC):
     @abstractmethod
     def min_bars_required(self) -> int:
         ...
+
+    @property
+    @abstractmethod
+    def worst_case(self) -> str:
+        """Describe the scenario where this strategy fails catastrophically."""
+        ...
+
+    @property
+    def last_reason(self) -> str:
+        """Human-readable reason for the last signal generated."""
+        return self._last_reason
 
     @abstractmethod
     def calculate(self, df: pd.DataFrame) -> pd.DataFrame:

--- a/backend/app/strategy/breakout.py
+++ b/backend/app/strategy/breakout.py
@@ -30,6 +30,10 @@ class BreakoutStrategy(BaseStrategy):
     def min_bars_required(self) -> int:
         return self.lookback + self.atr_period + 5
 
+    @property
+    def worst_case(self) -> str:
+        return "False breakouts in ranging markets — price spikes then immediately reverses"
+
     def get_params(self) -> dict:
         return {
             "lookback": self.lookback,

--- a/backend/app/strategy/dca.py
+++ b/backend/app/strategy/dca.py
@@ -1,0 +1,49 @@
+"""
+DCA (Dollar-Cost Averaging) Strategy — buy at fixed intervals, no indicators.
+
+The simplest possible strategy: buy every N bars regardless of price.
+No sell signals — exit via TP, manual close, or drawdown limit.
+
+Worst case: price drops continuously with no recovery.
+"""
+
+import pandas as pd
+
+from app.strategy.base import BaseStrategy
+from app.strategy.indicators import atr
+
+
+class DCAStrategy(BaseStrategy):
+    def __init__(self, interval_bars: int = 20):
+        self.interval_bars = interval_bars
+
+    @property
+    def name(self) -> str:
+        return "dca"
+
+    @property
+    def min_bars_required(self) -> int:
+        return self.interval_bars + 1
+
+    @property
+    def worst_case(self) -> str:
+        return "Price drops continuously with no recovery — accumulates large unrealized loss at progressively worse prices"
+
+    def get_params(self) -> dict:
+        return {"interval_bars": self.interval_bars}
+
+    def calculate(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = df.copy()
+        df["signal"] = 0
+        df["atr"] = atr(df["high"], df["low"], df["close"], 14)
+
+        # BUY every N bars — no indicators, no conditions
+        for i in range(self.interval_bars, len(df), self.interval_bars):
+            df.iloc[i, df.columns.get_loc("signal")] = 1
+
+        # Set last_reason
+        buy_indices = df.index[df["signal"] == 1]
+        if len(buy_indices) > 0:
+            self._last_reason = f"DCA scheduled buy (every {self.interval_bars} bars)"
+
+        return df

--- a/backend/app/strategy/ema_crossover.py
+++ b/backend/app/strategy/ema_crossover.py
@@ -21,6 +21,10 @@ class EMACrossoverStrategy(BaseStrategy):
     def min_bars_required(self) -> int:
         return self.slow_period + 5
 
+    @property
+    def worst_case(self) -> str:
+        return "Choppy/ranging markets cause repeated false crossovers and whipsaw losses"
+
     def get_params(self) -> dict:
         return {"fast_period": self.fast_period, "slow_period": self.slow_period}
 

--- a/backend/app/strategy/ensemble.py
+++ b/backend/app/strategy/ensemble.py
@@ -35,6 +35,10 @@ class EnsembleStrategy(BaseStrategy):
     def min_bars_required(self) -> int:
         return max(s.min_bars_required for s, _ in self._strategies)
 
+    @property
+    def worst_case(self) -> str:
+        return "All sub-strategies agree on wrong signal — correlated errors amplify losses"
+
     def calculate(self, df: pd.DataFrame) -> pd.DataFrame:
         df = df.copy()
         df["signal"] = 0

--- a/backend/app/strategy/grid.py
+++ b/backend/app/strategy/grid.py
@@ -1,0 +1,81 @@
+"""
+Grid Trading Strategy — buy below reference, sell above reference.
+
+Places signals at regular price intervals around a moving average reference.
+Stateless: grid levels recomputed each call from SMA.
+
+Worst case: strong one-directional trend without mean reversion.
+"""
+
+import pandas as pd
+
+from app.strategy.base import BaseStrategy
+from app.strategy.indicators import atr
+
+
+class GridStrategy(BaseStrategy):
+    def __init__(
+        self,
+        grid_spacing_pips: float = 5.0,
+        grid_levels: int = 5,
+        sma_period: int = 20,
+    ):
+        self.grid_spacing_pips = grid_spacing_pips
+        self.grid_levels = grid_levels
+        self.sma_period = sma_period
+
+    @property
+    def name(self) -> str:
+        return "grid"
+
+    @property
+    def min_bars_required(self) -> int:
+        return self.sma_period + 5
+
+    @property
+    def worst_case(self) -> str:
+        return "Strong one-directional trend without mean reversion — accumulates positions on wrong side with no grid profit to offset"
+
+    def get_params(self) -> dict:
+        return {
+            "grid_spacing_pips": self.grid_spacing_pips,
+            "grid_levels": self.grid_levels,
+            "sma_period": self.sma_period,
+        }
+
+    def calculate(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = df.copy()
+        df["signal"] = 0
+        df["atr"] = atr(df["high"], df["low"], df["close"], 14)
+        df["sma_ref"] = df["close"].rolling(self.sma_period).mean()
+
+        for i in range(self.sma_period, len(df)):
+            ref = df.iloc[i]["sma_ref"]
+            if pd.isna(ref):
+                continue
+            close = df.iloc[i]["close"]
+            prev_close = df.iloc[i - 1]["close"]
+
+            # Buy zones: price crosses below grid level
+            for level in range(1, self.grid_levels + 1):
+                grid_price = ref - (level * self.grid_spacing_pips)
+                if prev_close >= grid_price > close:
+                    df.iloc[i, df.columns.get_loc("signal")] = 1
+                    break
+
+            # Sell zones: price crosses above grid level
+            if df.iloc[i]["signal"] == 0:
+                for level in range(1, self.grid_levels + 1):
+                    grid_price = ref + (level * self.grid_spacing_pips)
+                    if prev_close <= grid_price < close:
+                        df.iloc[i, df.columns.get_loc("signal")] = -1
+                        break
+
+        # Set last_reason
+        signals = df[df["signal"] != 0]
+        if not signals.empty:
+            last = signals.iloc[-1]
+            direction = "BUY (below grid)" if last["signal"] == 1 else "SELL (above grid)"
+            self._last_reason = f"Grid {direction} — price={last['close']:.2f}, ref={last['sma_ref']:.2f}, spacing={self.grid_spacing_pips}"
+
+        return df

--- a/backend/app/strategy/mean_reversion.py
+++ b/backend/app/strategy/mean_reversion.py
@@ -33,6 +33,10 @@ class MeanReversionStrategy(BaseStrategy):
     def min_bars_required(self) -> int:
         return max(self._bb_period, self._rsi_period) + 10
 
+    @property
+    def worst_case(self) -> str:
+        return "Strong trending market — price breaks through bands without reverting, losses compound"
+
     def calculate(self, df: pd.DataFrame) -> pd.DataFrame:
         df = df.copy()
         df["signal"] = 0

--- a/backend/app/strategy/ml_strategy.py
+++ b/backend/app/strategy/ml_strategy.py
@@ -102,6 +102,10 @@ class MLStrategy(BaseStrategy):
     def min_bars_required(self) -> int:
         return 200
 
+    @property
+    def worst_case(self) -> str:
+        return "Model trained on past regime that no longer exists — overfitting to historical patterns, confident but wrong"
+
     def calculate(self, df: pd.DataFrame) -> pd.DataFrame:
         """Sync wrapper — actual work in _calculate_async called from engine."""
         df = df.copy()

--- a/backend/app/strategy/momentum_rank.py
+++ b/backend/app/strategy/momentum_rank.py
@@ -1,0 +1,119 @@
+"""
+Cross-Asset Momentum Rank Strategy — go long the strongest, short the weakest.
+
+Ranks all symbols by N-bar return. Strongest gets BUY, weakest gets SELL.
+Falls back to absolute momentum on single-symbol when cross-data unavailable.
+
+Worst case: momentum reversal — the strongest trending asset reverses sharply.
+"""
+
+import pandas as pd
+
+from app.strategy.base import BaseStrategy
+from app.strategy.indicators import atr, adx as calc_adx
+
+ALL_SYMBOLS = ["GOLD", "OILCash", "BTCUSD", "USDJPY"]
+
+
+class MomentumRankStrategy(BaseStrategy):
+    def __init__(
+        self,
+        lookback: int = 20,
+        atr_period: int = 14,
+        symbol: str = "GOLD",
+    ):
+        self._lookback = lookback
+        self._atr_period = atr_period
+        self._symbol = symbol
+        self._cross_returns: dict[str, float] = {}
+        self._rank: int | None = None
+
+    @property
+    def name(self) -> str:
+        return "momentum_rank"
+
+    @property
+    def min_bars_required(self) -> int:
+        return self._lookback + self._atr_period + 10
+
+    @property
+    def worst_case(self) -> str:
+        return "Momentum reversal — the strongest trending asset reverses sharply while the weakest mean-reverts upward"
+
+    def get_params(self) -> dict:
+        return {
+            "lookback": self._lookback,
+            "symbol": self._symbol,
+            "rank": self._rank,
+            "cross_returns": {k: round(v, 6) for k, v in self._cross_returns.items()},
+        }
+
+    async def _prepare_cross_data(self, market_data) -> None:
+        """Fetch N-bar returns for all symbols and rank them."""
+        import asyncio
+        self._cross_returns = {}
+        try:
+            dfs = await asyncio.gather(*[
+                market_data.get_ohlcv(sym, "M15", self._lookback + 10)
+                for sym in ALL_SYMBOLS
+            ])
+            for sym, df in zip(ALL_SYMBOLS, dfs):
+                if df is not None and not df.empty and len(df) >= self._lookback + 1:
+                    close_now = df["close"].iloc[-1]
+                    close_prev = df["close"].iloc[-self._lookback]
+                    if close_prev > 0:
+                        self._cross_returns[sym] = (close_now - close_prev) / close_prev
+        except Exception:
+            pass
+
+        if self._symbol in self._cross_returns and len(self._cross_returns) >= 2:
+            sorted_syms = sorted(self._cross_returns.keys(), key=lambda s: self._cross_returns[s], reverse=True)
+            self._rank = sorted_syms.index(self._symbol)
+
+    def calculate(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = df.copy()
+        df["signal"] = 0
+        df["atr"] = atr(df["high"], df["low"], df["close"], self._atr_period)
+
+        # ADX filter — only trade in trending markets
+        adx_result = calc_adx(df["high"], df["low"], df["close"], 14)
+        last_adx = adx_result["adx"].iloc[-1] if "adx" in adx_result else 20
+
+        if last_adx < 20:
+            self._last_reason = f"Momentum Rank HOLD — ADX {last_adx:.1f} < 20 (no trend)"
+            return df
+
+        n_symbols = len(self._cross_returns)
+
+        if self._rank is not None and n_symbols >= 2:
+            # Cross-asset ranking: apply signal to last bar only
+            last_idx = len(df) - 1
+            if self._rank == 0:  # strongest
+                df.iloc[last_idx, df.columns.get_loc("signal")] = 1
+                self._last_reason = f"Momentum Rank BUY — {self._symbol} ranked #1/{n_symbols} (return {self._cross_returns.get(self._symbol, 0):.2%})"
+            elif self._rank == n_symbols - 1:  # weakest
+                df.iloc[last_idx, df.columns.get_loc("signal")] = -1
+                self._last_reason = f"Momentum Rank SELL — {self._symbol} ranked #{n_symbols}/{n_symbols} (return {self._cross_returns.get(self._symbol, 0):.2%})"
+            else:
+                self._last_reason = f"Momentum Rank HOLD — {self._symbol} ranked #{self._rank + 1}/{n_symbols} (middle)"
+        else:
+            # Fallback: absolute momentum (single-symbol)
+            df["mom_return"] = df["close"].pct_change(self._lookback)
+            atr_pct = df["atr"].iloc[-1] / df["close"].iloc[-1] if df["close"].iloc[-1] > 0 else 0
+            threshold = max(atr_pct * 2, 0.005)
+
+            for i in range(self._lookback, len(df)):
+                ret = df.iloc[i]["mom_return"]
+                if pd.notna(ret):
+                    if ret > threshold:
+                        df.iloc[i, df.columns.get_loc("signal")] = 1
+                    elif ret < -threshold:
+                        df.iloc[i, df.columns.get_loc("signal")] = -1
+
+            signals = df[df["signal"] != 0]
+            if not signals.empty:
+                last = signals.iloc[-1]
+                direction = "BUY" if last["signal"] == 1 else "SELL"
+                self._last_reason = f"Abs Momentum {direction} — {self._lookback}-bar return={last.get('mom_return', 0):.2%}, threshold={threshold:.2%}"
+
+        return df

--- a/backend/app/strategy/pair_spread.py
+++ b/backend/app/strategy/pair_spread.py
@@ -1,0 +1,166 @@
+"""
+Pair Spread Strategy — mean reversion on correlated pair spread (z-score).
+
+GOLD and USDJPY have inverse correlation. Trades the z-score of their
+normalized price spread. Entry at ±2σ, exit at ±0.5σ.
+
+Falls back to single-symbol Bollinger z-score when pair data unavailable.
+
+Worst case: correlation breakdown — pair decouples permanently.
+"""
+
+import pandas as pd
+import numpy as np
+
+from app.strategy.base import BaseStrategy
+from app.strategy.indicators import atr
+
+PAIR_MAP = {"GOLD": "USDJPY", "USDJPY": "GOLD"}
+
+
+class PairSpreadStrategy(BaseStrategy):
+    def __init__(
+        self,
+        z_entry: float = 2.0,
+        z_exit: float = 0.5,
+        lookback: int = 50,
+        atr_period: int = 14,
+        symbol: str = "GOLD",
+        pair_symbol: str | None = None,
+    ):
+        self._z_entry = z_entry
+        self._z_exit = z_exit
+        self._lookback = lookback
+        self._atr_period = atr_period
+        self._symbol = symbol
+        self._pair_symbol = pair_symbol or PAIR_MAP.get(symbol)
+        self._pair_closes: pd.Series | None = None
+
+    @property
+    def name(self) -> str:
+        return "pair_spread"
+
+    @property
+    def min_bars_required(self) -> int:
+        return self._lookback + self._atr_period + 10
+
+    @property
+    def worst_case(self) -> str:
+        return "Correlation breakdown — pair decouples permanently (e.g., USD crisis where both gold and yen move same direction)"
+
+    def get_params(self) -> dict:
+        return {
+            "z_entry": self._z_entry,
+            "z_exit": self._z_exit,
+            "lookback": self._lookback,
+            "symbol": self._symbol,
+            "pair_symbol": self._pair_symbol,
+        }
+
+    async def _prepare_cross_data(self, market_data) -> None:
+        """Fetch pair symbol OHLCV for spread calculation."""
+        if not self._pair_symbol:
+            return
+        try:
+            pair_df = await market_data.get_ohlcv(self._pair_symbol, "M15", 250)
+            if pair_df is not None and not pair_df.empty and len(pair_df) >= self._lookback:
+                self._pair_closes = pair_df["close"]
+        except Exception:
+            self._pair_closes = None
+
+    def calculate(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = df.copy()
+        df["signal"] = 0
+        df["atr"] = atr(df["high"], df["low"], df["close"], self._atr_period)
+
+        if self._pair_closes is not None and len(self._pair_closes) >= self._lookback:
+            df = self._calculate_pair_spread(df)
+        else:
+            df = self._calculate_single_zscore(df)
+
+        return df
+
+    def _calculate_pair_spread(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Pair spread z-score using normalized prices."""
+        close_a = df["close"]
+
+        # Align pair data to same length
+        pair_len = min(len(close_a), len(self._pair_closes))
+        close_a_aligned = close_a.iloc[-pair_len:].reset_index(drop=True)
+        close_b_aligned = self._pair_closes.iloc[-pair_len:].reset_index(drop=True)
+
+        # Normalize: price / rolling mean
+        norm_a = close_a_aligned / close_a_aligned.rolling(self._lookback).mean()
+        norm_b = close_b_aligned / close_b_aligned.rolling(self._lookback).mean()
+
+        # Spread and z-score
+        spread = norm_a - norm_b
+        spread_mean = spread.rolling(self._lookback).mean()
+        spread_std = spread.rolling(self._lookback).std()
+        z_score = (spread - spread_mean) / spread_std.replace(0, np.nan)
+
+        # Map z_score back to original df index
+        offset = len(df) - pair_len
+        df["z_score"] = np.nan
+        for i in range(pair_len):
+            if pd.notna(z_score.iloc[i]):
+                df.iloc[offset + i, df.columns.get_loc("z_score")] = z_score.iloc[i]
+
+        # Generate signals based on z-score
+        is_inverted = self._symbol in ("USDJPY",)  # USDJPY is the "other side" of the pair
+
+        for i in range(offset + self._lookback, len(df)):
+            z = df.iloc[i]["z_score"]
+            if pd.isna(z):
+                continue
+
+            if is_inverted:
+                # USDJPY: buy when spread is high (USDJPY underperforming)
+                if z > self._z_entry:
+                    df.iloc[i, df.columns.get_loc("signal")] = 1
+                elif z < -self._z_entry:
+                    df.iloc[i, df.columns.get_loc("signal")] = -1
+            else:
+                # GOLD: buy when spread is low (GOLD underperforming)
+                if z < -self._z_entry:
+                    df.iloc[i, df.columns.get_loc("signal")] = 1
+                elif z > self._z_entry:
+                    df.iloc[i, df.columns.get_loc("signal")] = -1
+
+        # Set reason
+        last_z = df["z_score"].dropna()
+        if not last_z.empty:
+            z_val = last_z.iloc[-1]
+            signals = df[df["signal"] != 0]
+            if not signals.empty:
+                direction = "BUY" if signals.iloc[-1]["signal"] == 1 else "SELL"
+                self._last_reason = f"Pair Spread {direction} — {self._symbol}/{self._pair_symbol} z-score={z_val:.2f} (entry=±{self._z_entry})"
+            else:
+                self._last_reason = f"Pair Spread HOLD — z-score={z_val:.2f} (within ±{self._z_entry})"
+
+        return df
+
+    def _calculate_single_zscore(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Fallback: single-symbol Bollinger z-score mean reversion."""
+        close = df["close"]
+        rolling_mean = close.rolling(self._lookback).mean()
+        rolling_std = close.rolling(self._lookback).std()
+        z_score = (close - rolling_mean) / rolling_std.replace(0, np.nan)
+        df["z_score"] = z_score
+
+        for i in range(self._lookback, len(df)):
+            z = df.iloc[i]["z_score"]
+            if pd.isna(z):
+                continue
+            if z < -self._z_entry:
+                df.iloc[i, df.columns.get_loc("signal")] = 1
+            elif z > self._z_entry:
+                df.iloc[i, df.columns.get_loc("signal")] = -1
+
+        signals = df[df["signal"] != 0]
+        if not signals.empty:
+            last = signals.iloc[-1]
+            direction = "BUY" if last["signal"] == 1 else "SELL"
+            self._last_reason = f"Z-Score {direction} — {self._symbol} z={last['z_score']:.2f} (single-symbol fallback, entry=±{self._z_entry})"
+
+        return df

--- a/backend/app/strategy/regime.py
+++ b/backend/app/strategy/regime.py
@@ -63,3 +63,88 @@ REGIME_ADJUSTMENTS = {
 def get_regime_adjustments(regime: str) -> dict:
     """Get SL/TP adjustment factors for the given regime."""
     return REGIME_ADJUSTMENTS.get(regime, REGIME_ADJUSTMENTS["normal"])
+
+
+# ─── Multi-Timeframe Regime ────────────────────────────────────────────────
+
+from collections import Counter
+from dataclasses import dataclass
+
+
+@dataclass
+class MultiTFRegime:
+    m15_regime: str
+    h1_regime: str
+    h4_regime: str
+    composite: str          # dominant regime across timeframes
+    suggested_style: str    # "scalp" | "intraday" | "swing"
+    agreement_score: float  # 0.0-1.0 how aligned the TFs are
+
+    def to_dict(self) -> dict:
+        return {
+            "m15": self.m15_regime,
+            "h1": self.h1_regime,
+            "h4": self.h4_regime,
+            "composite": self.composite,
+            "style": self.suggested_style,
+            "agreement": self.agreement_score,
+        }
+
+
+# (composite_regime, high_agreement) → trading style
+STYLE_MAP = {
+    ("trending_high_vol", True): "swing",
+    ("trending_high_vol", False): "intraday",
+    ("trending_low_vol", True): "intraday",
+    ("trending_low_vol", False): "scalp",
+    ("ranging", True): "scalp",
+    ("ranging", False): "scalp",
+    ("normal", True): "intraday",
+    ("normal", False): "scalp",
+}
+
+
+def _compute_composite(regimes: list[str]) -> tuple[str, float]:
+    """Pick dominant regime via majority vote. Returns (regime, agreement_score)."""
+    counts = Counter(regimes)
+    dominant, top_count = counts.most_common(1)[0]
+    agreement = top_count / len(regimes)
+    return dominant, round(agreement, 2)
+
+
+def _regime_from_df(df) -> str:
+    """Detect regime from a single-timeframe OHLCV DataFrame."""
+    if df is None or df.empty or len(df) < 16:
+        return "normal"
+    from app.strategy.indicators import atr as calc_atr, adx as calc_adx
+    atr_val = calc_atr(df["high"], df["low"], df["close"]).iloc[-1]
+    adx_result = calc_adx(df["high"], df["low"], df["close"])
+    adx_val = adx_result["adx"].iloc[-1] if "adx" in adx_result else 20
+    price = df["close"].iloc[-1]
+    atr_pct = atr_val / price if price > 0 else 0
+    return detect_regime(atr_pct, adx_val)
+
+
+async def detect_multi_tf_regime(market_data, symbol: str) -> MultiTFRegime:
+    """Fetch M15+H1+H4, detect regime on each, return composite."""
+    import asyncio
+    from app.constants import DEFAULT_OHLCV_BARS
+
+    try:
+        m15_df, h1_df, h4_df = await asyncio.gather(
+            market_data.get_ohlcv(symbol, "M15", DEFAULT_OHLCV_BARS),
+            market_data.get_ohlcv(symbol, "H1", 50),
+            market_data.get_ohlcv(symbol, "H4", 50),
+        )
+    except Exception:
+        return MultiTFRegime("normal", "normal", "normal", "normal", "intraday", 1.0)
+
+    m15 = _regime_from_df(m15_df)
+    h1 = _regime_from_df(h1_df)
+    h4 = _regime_from_df(h4_df)
+
+    composite, agreement = _compute_composite([m15, h1, h4])
+    high_agreement = agreement >= 0.67
+    style = STYLE_MAP.get((composite, high_agreement), "intraday")
+
+    return MultiTFRegime(m15, h1, h4, composite, style, agreement)

--- a/backend/app/strategy/risk_parity.py
+++ b/backend/app/strategy/risk_parity.py
@@ -1,0 +1,105 @@
+"""
+Risk Parity Strategy — allocate position size inversely proportional to volatility.
+
+Uses EMA crossover for signal direction, but the real value is the vol_weight:
+less lot for volatile assets, more for calm ones. Engine reads vol_weight from get_params().
+
+Worst case: low-volatility asset gets oversized position, then volatility spikes.
+"""
+
+import pandas as pd
+
+from app.strategy.base import BaseStrategy
+from app.strategy.indicators import atr, ema
+
+
+ALL_SYMBOLS = ["GOLD", "OILCash", "BTCUSD", "USDJPY"]
+
+
+class RiskParityStrategy(BaseStrategy):
+    def __init__(
+        self,
+        ema_fast: int = 20,
+        ema_slow: int = 50,
+        atr_period: int = 14,
+        vol_lookback: int = 50,
+        symbol: str = "GOLD",
+    ):
+        self._ema_fast = ema_fast
+        self._ema_slow = ema_slow
+        self._atr_period = atr_period
+        self._vol_lookback = vol_lookback
+        self._symbol = symbol
+        self._vol_weight: float = 0.25  # default equal weight
+        self._all_vol_weights: dict[str, float] = {}
+
+    @property
+    def name(self) -> str:
+        return "risk_parity"
+
+    @property
+    def min_bars_required(self) -> int:
+        return max(self._vol_lookback, self._ema_slow) + 10
+
+    @property
+    def worst_case(self) -> str:
+        return "Low-volatility asset gets oversized position, then volatility spikes — concentrated loss in the 'safe' asset"
+
+    def get_params(self) -> dict:
+        return {
+            "ema_fast": self._ema_fast,
+            "ema_slow": self._ema_slow,
+            "vol_weight": round(self._vol_weight, 4),
+            "all_weights": self._all_vol_weights,
+        }
+
+    async def _prepare_cross_data(self, market_data) -> None:
+        """Fetch ATR of all symbols and compute inverse-volatility weights."""
+        import asyncio
+        atr_pcts = {}
+        try:
+            dfs = await asyncio.gather(*[
+                market_data.get_ohlcv(sym, "M15", self._vol_lookback + 20)
+                for sym in ALL_SYMBOLS
+            ])
+            for sym, df in zip(ALL_SYMBOLS, dfs):
+                if df is not None and not df.empty and len(df) >= self._atr_period + 2:
+                    atr_val = atr(df["high"], df["low"], df["close"], self._atr_period).iloc[-1]
+                    price = df["close"].iloc[-1]
+                    if price > 0:
+                        atr_pcts[sym] = atr_val / price
+        except Exception:
+            pass
+
+        if len(atr_pcts) >= 2:
+            inv_vols = {sym: 1.0 / max(v, 0.0001) for sym, v in atr_pcts.items()}
+            total = sum(inv_vols.values())
+            self._all_vol_weights = {sym: round(v / total, 4) for sym, v in inv_vols.items()}
+            self._vol_weight = self._all_vol_weights.get(self._symbol, 0.25)
+
+    def calculate(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = df.copy()
+        df["signal"] = 0
+        df["atr"] = atr(df["high"], df["low"], df["close"], self._atr_period)
+        df["ema_fast"] = ema(df["close"], self._ema_fast)
+        df["ema_slow"] = ema(df["close"], self._ema_slow)
+
+        # EMA crossover signals
+        for i in range(self._ema_slow + 1, len(df)):
+            fast_prev = df.iloc[i - 1]["ema_fast"]
+            fast_curr = df.iloc[i]["ema_fast"]
+            slow_prev = df.iloc[i - 1]["ema_slow"]
+            slow_curr = df.iloc[i]["ema_slow"]
+
+            if fast_prev <= slow_prev and fast_curr > slow_curr:
+                df.iloc[i, df.columns.get_loc("signal")] = 1
+            elif fast_prev >= slow_prev and fast_curr < slow_curr:
+                df.iloc[i, df.columns.get_loc("signal")] = -1
+
+        signals = df[df["signal"] != 0]
+        if not signals.empty:
+            last = signals.iloc[-1]
+            direction = "BUY" if last["signal"] == 1 else "SELL"
+            self._last_reason = f"Risk Parity {direction} — vol_weight={self._vol_weight:.2%} (EMA{self._ema_fast}/{self._ema_slow} crossover)"
+
+        return df

--- a/backend/app/strategy/rsi_filter.py
+++ b/backend/app/strategy/rsi_filter.py
@@ -33,6 +33,10 @@ class RSIFilterStrategy(BaseStrategy):
     def min_bars_required(self) -> int:
         return max(self.ema_slow, self.rsi_period) + 5
 
+    @property
+    def worst_case(self) -> str:
+        return "Extended overbought/oversold in strong trends — RSI stays extreme while price continues"
+
     def get_params(self) -> dict:
         return {
             "ema_fast": self.ema_fast,

--- a/backend/mcp_server/agent_config.py
+++ b/backend/mcp_server/agent_config.py
@@ -77,7 +77,7 @@ def _build_user_message(job_type: str, job_input: dict | None) -> str:
     if job_type == "candle_analysis":
         symbol = (job_input or {}).get("symbol", "GOLD")
         timeframe = (job_input or {}).get("timeframe", "M15")
-        return f"A new {timeframe} candle has closed for {symbol}. Analyze and decide whether to trade.\n\nJob input: {input_str}"
+        return f"A new {timeframe} candle has closed for {symbol}. Analyze market conditions, detect regime, flag risks. Trading is handled by the strategy engine.\n\nJob input: {input_str}"
     elif job_type == "manual_analysis":
         symbol = (job_input or {}).get("symbol", "GOLD")
         return f"Manual analysis requested for {symbol}. Provide thorough analysis with recommendation.\n\nJob input: {input_str}"

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -79,25 +79,11 @@ def create_server() -> FastMCP:
         """Calculate stop-loss and take-profit levels."""
         return risk.calculate_sl_tp(symbol, entry_price, signal, atr)
 
-    # ─── Broker Tools (GUARDRAIL-GATED execution) ────────────────────────
+    # ─── Broker Tools (read-only — execution disabled for AI agent) ────
 
-    @mcp.tool()
-    async def place_order(
-        symbol: str, order_type: str, lot: float, sl: float, tp: float, comment: str = ""
-    ) -> dict:
-        """Place a trade order. GUARDRAIL-GATED: every order passes through
-        non-bypassable validation before execution."""
-        return await broker.place_order(symbol, order_type, lot, sl, tp, comment)
-
-    @mcp.tool()
-    async def modify_position(ticket: int, sl: float | None = None, tp: float | None = None) -> dict:
-        """Modify stop-loss and/or take-profit of an existing position."""
-        return await broker.modify_position(ticket, sl, tp)
-
-    @mcp.tool()
-    async def close_position(ticket: int) -> dict:
-        """Close a specific position by ticket number."""
-        return await broker.close_position(ticket)
+    # NOTE: place_order, modify_position, close_position REMOVED from AI agent.
+    # Trading execution is handled by the strategy engine (engine.process_candle).
+    # AI agent is an analyst, not a decision-maker.
 
     @mcp.tool()
     async def get_positions(symbol: str | None = None) -> dict:

--- a/backend/mcp_server/system_prompt.md
+++ b/backend/mcp_server/system_prompt.md
@@ -1,88 +1,56 @@
-You are an autonomous trading agent. You analyze markets, manage risk, and execute trades for GOLD (XAUUSD), OILCash, BTCUSD, and USDJPY.
+You are a market analyst agent for an automated trading system. You analyze markets for GOLD (XAUUSD), OILCash, BTCUSD, and USDJPY.
 
 ## Language
 
 **ตอบเป็นภาษาไทยเสมอ** ยกเว้นศัพท์เทคนิคที่ไม่ต้องแปล เช่น:
 - ชื่อ indicator: EMA, RSI, ATR, ADX, Bollinger Band, MACD
 - คำเทรด: BUY, SELL, HOLD, SL, TP, lot, pip, spread
-- ชื่อ strategy: Trend Following, Mean Reversion, Breakout, Momentum
+- ชื่อ strategy: Trend Following, Mean Reversion, Breakout, DCA, Grid
 - ชื่อ symbol: GOLD, OILCash, BTCUSD, USDJPY
 - ตัวเลข, ราคา, เปอร์เซ็นต์
 
-ตัวอย่าง: "ตลาดอยู่ในช่วง transitional — ADX 24.16 ยังไม่ถึง 25 ที่จะยืนยัน trend ชัดเจน RSI 50.72 อยู่ในโซน neutral ตัดสินใจ HOLD รอสัญญาณที่ชัดกว่านี้"
-
 ## Your Role
 
-You are the **sole decision-maker**. There are no rule-based strategies — you decide everything based on your analysis. You must choose which trading approach to use and explain why.
+You are a **market analyst**, NOT a decision-maker. Trading decisions are made by rule-based strategies (DCA, Grid, EMA Crossover, etc.). Your role:
 
-## Available Trading Strategies
+1. **Analyze market conditions** — detect regime, identify risks, assess sentiment
+2. **Flag warnings** — macro events, unusual volatility, news that could impact trades
+3. **Provide context** — help the human trader understand what's happening and why
+4. **Log observations** — your analysis is displayed on the dashboard
 
-Choose the best approach based on current market conditions:
+**You do NOT place orders or execute trades.** The strategy engine handles execution.
 
-- **Trend Following**: Use when ADX > 25 and clear EMA alignment. Trade in trend direction.
-- **Mean Reversion**: Use when ADX < 20 and price at Bollinger Band extremes. Fade the move.
-- **Breakout**: Use when price breaks N-period high/low with volume confirmation.
-- **Momentum**: Use when RSI shows strong momentum (not yet overbought/oversold).
-- **Hold / No Trade**: Use when signals conflict, spreads are wide, or risk is too high.
-
-## Decision Framework
+## Analysis Framework
 
 For each candle close:
 
 1. **Detect Regime**: Use `detect_regime` or `run_full_analysis` to classify the market
-2. **Choose Strategy**: Pick the best approach for current conditions
-3. **Gather Data**: Use `run_full_analysis` for comprehensive indicators
-4. **Check Sentiment**: Use `get_sentiment` for directional bias
-5. **Review Portfolio**: Use `get_exposure` and `get_account` for risk context
-6. **Decide**: BUY, SELL, or HOLD with specific reasoning
-7. **If Trading**:
-   - Calculate position size with `calculate_lot_size`
-   - Calculate SL/TP with `calculate_sl_tp`
-   - Validate with `validate_trade`
-   - Execute with `place_order`
-8. **Log**: ALWAYS call `log_decision` with:
-   - Your decision (BUY/SELL/HOLD)
-   - Which strategy you chose and why
-   - Key indicator values that influenced your decision
+2. **Assess Conditions**: Gather indicators, check sentiment
+3. **Review Portfolio**: Use `get_exposure` and `get_account` for risk context
+4. **Flag Risks**: Macro events, extreme volatility, conflicting signals
+5. **Recommend**: Suggest whether current strategy is appropriate for conditions
+6. **Log**: ALWAYS call `log_decision` with:
+   - Market conditions summary
+   - Regime classification
+   - Risk flags (if any)
+   - Strategy recommendation (which strategy fits current regime)
    - Confidence level (0.0-1.0)
-
-## Important: Strategy Reporting
-
-When you call `log_decision`, include the strategy name in your reasoning:
-- "Strategy: Trend Following — EMA bullish crossover, ADX 32, RSI 58"
-- "Strategy: Hold — conflicting signals, ADX 18 (no trend), spread elevated"
-- "Strategy: Mean Reversion — price at lower Bollinger Band, RSI 28 oversold"
-
-## Trading Philosophy
-
-- **Quality over quantity**: 2-3 high-conviction trades per day is ideal
-- **Risk first**: Never risk more than 1% per trade, 3% daily max
-- **Adapt**: Switch strategies based on market regime — don't force one approach
-- **Patience**: No trade is better than a bad trade — HOLD is always valid
-- **News awareness**: Reduce size before major events (NFP, FOMC, CPI)
-- **Spread sensitivity**: Don't trade when spreads > 3x average
 
 ## Trump / Trade Policy Factor (2025-2026)
 
 Trump's tariff and trade policies are a **dominant market driver**. Always factor them in:
 
-- **Tariff escalation** (new tariffs, trade war with China/EU/Japan):
-  - GOLD ↑ (safe-haven demand), OIL ↓ (recession fears), USDJPY ↓ (yen safe-haven)
-  - Increase volatility expectations, reduce lot sizes, prefer HOLD if uncertain
-- **De-escalation** (deals, exemptions, pauses):
-  - GOLD ↓ (risk-on), OIL ↑ (growth optimism), USDJPY ↑ (risk-on)
-- **Sanctions** (Iran, Venezuela, Russia):
-  - OIL ↑ (supply disruption), GOLD ↑ (geopolitical risk)
-- **When you see Trump-related headlines in sentiment data**: Weight them 2x compared to routine economic data. A single tariff tweet can override weeks of technical signals.
-- **If Trump news conflicts with technicals**: Prefer HOLD or reduce position size.
+- **Tariff escalation**: GOLD ↑ (safe-haven), OIL ↓ (recession fears), USDJPY ↓ (yen safe-haven)
+- **De-escalation**: GOLD ↓ (risk-on), OIL ↑ (growth optimism)
+- **Sanctions**: OIL ↑ (supply disruption), GOLD ↑ (geopolitical risk)
+- **When you see Trump-related headlines**: Flag them as high-impact warnings
 
 ## Key Rules
 
-- You MUST log every decision with `log_decision`, including HOLD
-- You MUST include the strategy name in every log
-- You MUST check current positions before opening new ones
-- You MUST use stop-loss and take-profit on every trade
-- You MUST NOT bypass guardrails
+- You MUST log every analysis with `log_decision`
+- You MUST include regime and risk assessment in every log
+- You MUST flag macro events within 4 hours
+- You MUST NOT call place_order, modify_position, or close_position — these are not your tools
 - If errors occur, log them and skip — don't retry blindly
 
 ## Symbols

--- a/backend/tests/integration/test_engine.py
+++ b/backend/tests/integration/test_engine.py
@@ -57,7 +57,7 @@ class TestBotEngine:
     async def test_get_status(self, engine):
         status = engine.get_status()
         assert status["state"] == "STOPPED"
-        assert status["strategy"] == "ai_autonomous"
+        assert status["strategy"] == "ema_crossover"
         assert status["symbol"] == "GOLD"
         assert "max_risk_per_trade" in status
 

--- a/frontend/app/backtest/page.tsx
+++ b/frontend/app/backtest/page.tsx
@@ -33,6 +33,11 @@ const STRATEGIES = [
   { value: "breakout", label: "Breakout" },
   { value: "mean_reversion", label: "Mean Reversion" },
   { value: "ml_signal", label: "ML Signal" },
+  { value: "dca", label: "DCA (ถัวเฉลี่ย)" },
+  { value: "grid", label: "Grid Trading" },
+  { value: "risk_parity", label: "Risk Parity" },
+  { value: "momentum_rank", label: "Momentum Rank" },
+  { value: "pair_spread", label: "Pair Spread" },
 ];
 
 
@@ -68,6 +73,27 @@ const STRATEGY_PARAMS: Record<string, ParamDef[]> = {
     { key: "min_bandwidth", label: "Min Bandwidth", defaults: [0.003, 0.005, 0.01] },
   ],
   ml_signal: [],
+  dca: [
+    { key: "interval_bars", label: "Interval (bars)", defaults: [10, 15, 20, 30, 50] },
+  ],
+  grid: [
+    { key: "grid_spacing_pips", label: "Grid Spacing (pips)", defaults: [3, 5, 8, 10] },
+    { key: "grid_levels", label: "Grid Levels", defaults: [3, 5, 7, 10] },
+    { key: "sma_period", label: "SMA Period", defaults: [15, 20, 30] },
+  ],
+  risk_parity: [
+    { key: "ema_fast", label: "EMA Fast", defaults: [15, 20, 25] },
+    { key: "ema_slow", label: "EMA Slow", defaults: [40, 50, 60] },
+    { key: "vol_lookback", label: "Vol Lookback", defaults: [30, 50, 80] },
+  ],
+  momentum_rank: [
+    { key: "lookback", label: "Momentum Lookback", defaults: [10, 15, 20, 30] },
+  ],
+  pair_spread: [
+    { key: "z_entry", label: "Z-Score Entry", defaults: [1.5, 2.0, 2.5, 3.0] },
+    { key: "z_exit", label: "Z-Score Exit", defaults: [0.3, 0.5, 0.8] },
+    { key: "lookback", label: "Lookback", defaults: [30, 50, 80] },
+  ],
 };
 
 function buildDefaultGridInputs(strat: string): Record<string, string> {

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -48,6 +48,14 @@ const STRATEGY_TH: Record<string, string> = {
   breakout: "ทะลุแนวรับ/ต้าน",
   ai_autonomous: "AI อัตโนมัติ",
   scalping: "สแคลป์ปิง",
+  ema_crossover: "EMA Crossover",
+  rsi_filter: "RSI Filter",
+  dca: "DCA ถัวเฉลี่ย",
+  grid: "Grid เทรด",
+  risk_parity: "Risk Parity",
+  momentum_rank: "Momentum Rank",
+  pair_spread: "Pair Spread",
+  ml_signal: "ML Signal",
 };
 
 export default function DashboardPage() {
@@ -56,7 +64,7 @@ export default function DashboardPage() {
     setActiveSymbol, setSymbols, setStatus, setSymbolStatuses, setPositions, setSentiment, setTick, addEvent,
   } = useBotStore();
   const [loading, setLoading] = useState(true);
-  const [account, setAccount] = useState<{ balance: number; equity: number; margin: number; free_margin: number; profit: number; accounts?: { connector: string; balance: number; equity: number; currency: string }[] } | null>(null);
+  const [account, setAccount] = useState<{ balance: number; equity: number; margin: number; free_margin: number; profit: number; peak_balance?: number; drawdown_pct?: number; accounts?: { connector: string; balance: number; equity: number; currency: string }[] } | null>(null);
   const [dailyPnl, setDailyPnl] = useState<{ daily_pnl: number; trade_count: number; wins: number; losses: number } | null>(null);
   const [news, setNews] = useState<
     { headline: string; source: string; sentiment_label: string; sentiment_score: number; created_at: string }[]
@@ -326,7 +334,7 @@ export default function DashboardPage() {
       )}
 
       {/* Stats Cards */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 animate-fade-in" style={{ animationDelay: "0.05s" }}>
+      <div className="grid grid-cols-2 lg:grid-cols-3 gap-4 animate-fade-in" style={{ animationDelay: "0.05s" }}>
         <StatCard
           icon={TrendingUp}
           label="Unrealized P&L"
@@ -350,6 +358,18 @@ export default function DashboardPage() {
           label="Bot Status"
           value={status?.state || "UNKNOWN"}
           variant={isRunning ? "success" : "warning"}
+        />
+        <StatCard
+          icon={ShieldAlert}
+          label="Drawdown"
+          value={account?.drawdown_pct != null ? `${(account.drawdown_pct * 100).toFixed(1)}%` : "—"}
+          subtitle={account?.peak_balance ? `Peak: $${account.peak_balance.toFixed(0)}` : undefined}
+          variant={
+            !account?.drawdown_pct ? "default"
+            : account.drawdown_pct < 0.05 ? "success"
+            : account.drawdown_pct < 0.10 ? "warning"
+            : "danger"
+          }
         />
       </div>
 
@@ -416,6 +436,35 @@ export default function DashboardPage() {
                 <span className="font-medium">Symbol</span>
                 <span className="text-foreground font-semibold">{activeSymbol}</span>
               </div>
+              {(status?.multi_tf_regime || status?.regime) && (
+                <div className="space-y-1">
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium">Regime</span>
+                    <Badge variant="outline" className={`text-[10px] ${
+                      (status.multi_tf_regime?.composite || status.regime) === "trending_high_vol" ? "border-red-500/30 text-red-400" :
+                      (status.multi_tf_regime?.composite || status.regime) === "ranging" ? "border-blue-500/30 text-blue-400" :
+                      (status.multi_tf_regime?.composite || status.regime) === "trending_low_vol" ? "border-green-500/30 text-green-400" :
+                      "border-border text-muted-foreground"
+                    }`}>
+                      {(status.multi_tf_regime?.composite || status.regime) === "trending_high_vol" ? "🔥 Trend+HV" :
+                       (status.multi_tf_regime?.composite || status.regime) === "trending_low_vol" ? "📊 Trend+LV" :
+                       (status.multi_tf_regime?.composite || status.regime) === "ranging" ? "↔️ Ranging" :
+                       "⚖️ Normal"}
+                      {status.multi_tf_regime?.style && ` · ${status.multi_tf_regime.style}`}
+                    </Badge>
+                  </div>
+                  {status.multi_tf_regime && (
+                    <div className="flex gap-1 justify-end">
+                      {(["m15", "h1", "h4"] as const).map((tf) => {
+                        const r = status.multi_tf_regime?.[tf];
+                        const short = r === "trending_high_vol" ? "T↑" : r === "trending_low_vol" ? "T↓" : r === "ranging" ? "R" : "N";
+                        const color = r === "trending_high_vol" ? "text-red-400" : r === "ranging" ? "text-blue-400" : r === "trending_low_vol" ? "text-green-400" : "text-muted-foreground";
+                        return <span key={tf} className={`text-[9px] font-mono ${color}`}>{tf.toUpperCase()}:{short}</span>;
+                      })}
+                    </div>
+                  )}
+                </div>
+              )}
               <div className="flex items-center justify-between">
                 <span className="font-medium">Timeframe</span>
                 <Select

--- a/frontend/app/history/page.tsx
+++ b/frontend/app/history/page.tsx
@@ -25,6 +25,9 @@ type Trade = {
   open_price: number; close_price: number | null; sl: number; tp: number;
   open_time: string; close_time: string | null; profit: number | null;
   strategy_name: string; ai_sentiment_label: string | null; ai_sentiment_score: number | null;
+  trade_reason: string | null;
+  pre_trade_snapshot: Record<string, unknown> | null;
+  post_trade_analysis: { exit_reason: string; duration_hours: number | null; outcome: string; profit_usd: number; entry_regime: string; exit_regime: string | null; summary_th: string } | null;
 };
 
 export default function HistoryPage() {
@@ -140,6 +143,7 @@ export default function HistoryPage() {
                         <TableHead className="text-right">Close</TableHead>
                         <TableHead className="text-right">P&L</TableHead>
                         <TableHead>Strategy</TableHead>
+                        <TableHead>Reason</TableHead>
                         <TableHead className="text-center">AI</TableHead>
                       </TableRow>
                     </TableHeader>
@@ -157,7 +161,7 @@ export default function HistoryPage() {
                             >
                               {total >= 0 ? "+" : ""}{total.toFixed(2)}
                             </TableCell>
-                            <TableCell colSpan={2} />
+                            <TableCell colSpan={3} />
                           </TableRow>
                         ) : null;
                       })()}
@@ -183,6 +187,9 @@ export default function HistoryPage() {
                             {t.profit !== null ? `${t.profit >= 0 ? "+" : ""}${t.profit.toFixed(2)}` : "—"}
                           </TableCell>
                           <TableCell className="text-muted-foreground font-medium">{t.strategy_name}</TableCell>
+                          <TableCell className="text-muted-foreground text-xs max-w-[200px] truncate" title={t.trade_reason || undefined}>
+                            {t.trade_reason || "—"}
+                          </TableCell>
                           <TableCell className="text-center">
                             {t.ai_sentiment_label ? (
                               <SentimentBadge label={t.ai_sentiment_label} score={t.ai_sentiment_score || 0} size="sm" />

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import { PageHeader } from "@/components/layout/PageHeader";
 import {
-  getBotStatus, updateSettings, getRolloutMode, setRolloutMode, getRolloutReadiness,
+  getBotStatus, updateSettings, updateStrategy, getRolloutMode, setRolloutMode, getRolloutReadiness, getAvailableStrategies,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
@@ -23,6 +23,7 @@ type Check = { name: string; status: string; detail: string };
 type SymbolStatus = {
   symbol: string;
   state: string;
+  strategy: string;
   timeframe: string;
   paper_trade: boolean;
   max_lot: number;
@@ -69,13 +70,15 @@ export default function SettingsPage() {
   const [checks, setChecks] = useState<Check[]>([]);
   const [readiness, setReadiness] = useState<{ ready: boolean; errors: number; warnings: number } | null>(null);
   const [confirmLive, setConfirmLive] = useState(false);
+  const [strategies, setStrategies] = useState<{ name: string; worst_case: string }[]>([]);
 
   const fetchAll = useCallback(async () => {
     try {
-      const [rolloutRes, statusRes, readinessRes] = await Promise.all([
+      const [rolloutRes, statusRes, readinessRes, stratRes] = await Promise.all([
         getRolloutMode().catch(() => null),
         getBotStatus().catch(() => null),
         getRolloutReadiness().catch(() => null),
+        getAvailableStrategies().catch(() => null),
       ]);
 
       if (rolloutRes?.data) {
@@ -91,6 +94,9 @@ export default function SettingsPage() {
           errors: readinessRes.data.errors,
           warnings: readinessRes.data.warnings,
         });
+      }
+      if (stratRes?.data?.strategies) {
+        setStrategies(stratRes.data.strategies);
       }
     } catch {
       /* handled */
@@ -143,12 +149,34 @@ export default function SettingsPage() {
     <div className="p-4 sm:p-6 xl:p-8 space-y-5 sm:space-y-6 max-w-4xl">
       <PageHeader title="Settings" subtitle="Trading mode, risk parameters, and system health" />
 
-      {/* ── Trading Mode ─────────────────────────────────────── */}
+      {/* ── Decision Mode ────────────────────────────────────── */}
+      <Card>
+        <CardHeader className="p-4 sm:p-6">
+          <CardTitle className="text-sm font-bold flex items-center gap-2">
+            <Info className="size-4" />
+            Decision Mode
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-4 pt-0 sm:p-6 sm:pt-0">
+          <div className="rounded-xl border border-green-500/30 bg-green-500/5 p-4">
+            <p className="text-sm font-bold text-green-400">Strategy-First (AI Filter)</p>
+            <p className="text-xs text-muted-foreground mt-1">
+              Rule-based strategies (DCA, Grid, EMA, etc.) generate trade signals.
+              AI analyzes market conditions and provides context on the dashboard — it does NOT execute trades.
+            </p>
+          </div>
+          <p className="text-[11px] text-muted-foreground mt-2">
+            Strategy สร้าง signal → AI filter ดูข่าว/event → Risk manager ตรวจ regime/drawdown → เปิด trade
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* ── Rollout Mode ──────────────────────────────────────── */}
       <Card>
         <CardHeader className="p-4 sm:p-6">
           <CardTitle className="text-sm font-bold flex items-center gap-2">
             <Shield className="size-4" />
-            Trading Mode
+            Rollout Mode
           </CardTitle>
         </CardHeader>
         <CardContent className="p-4 pt-0 sm:p-6 sm:pt-0 space-y-4">
@@ -249,6 +277,43 @@ export default function SettingsPage() {
               </div>
 
               <Separator />
+
+              {/* Strategy selector + worst case */}
+              {strategies.length > 0 && (
+                <div className="space-y-1.5">
+                  <div className="flex items-center gap-3">
+                    <div className="space-y-1 flex-1">
+                      <label className="text-xs text-muted-foreground font-medium">Strategy</label>
+                      <Select
+                        value={st.strategy || "ai_autonomous"}
+                        onValueChange={async (v) => {
+                          if (!v) return;
+                          await updateStrategy(v, undefined, symbol || undefined);
+                          const res = await getBotStatus().catch(() => null);
+                          if (res?.data?.symbols) setSymbolStatuses(res.data.symbols);
+                        }}
+                      >
+                        <SelectTrigger className="h-8 text-xs"><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="ai_autonomous">AI Autonomous</SelectItem>
+                          {strategies.map((s) => (
+                            <SelectItem key={s.name} value={s.name}>{s.name}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                  {(() => {
+                    const selected = strategies.find((s) => s.name === st.strategy);
+                    return selected?.worst_case ? (
+                      <p className="text-[11px] text-amber-500/80 leading-snug">
+                        <AlertTriangle className="size-3 inline mr-1" />
+                        Worst case: {selected.worst_case}
+                      </p>
+                    ) : null;
+                  })()}
+                </div>
+              )}
 
               <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-3 text-xs">
                 {/* Lot Mode */}

--- a/frontend/store/botStore.ts
+++ b/frontend/store/botStore.ts
@@ -33,6 +33,8 @@ type BotStatus = {
   paper_trade: boolean;
   max_lot?: number;
   fixed_lot?: number | null;
+  regime?: string;
+  multi_tf_regime?: { m15: string; h1: string; h4: string; composite: string; style: string; agreement: number } | null;
   sentiment?: Sentiment;
   ai_decision?: {
     decision: string;


### PR DESCRIPTION
## Summary
Major architecture shift from "AI decides everything" to "Strategy decides, AI filters" + 5 new strategies (2 basic + 3 quant) + comprehensive risk/regime/transparency enhancements.

## Architecture Change
- **Before:** AI agent was sole decision-maker, `process_candle()` was dead code
- **After:** Strategy generates signals via `process_candle()`, AI runs in parallel as analyst only
- AI agent tools: removed `place_order`, `modify_position`, `close_position` (read-only)
- New `trading_mode` config: `"strategy"` (default) / `"ai_autonomous"`

## New Strategies (10 total)
| Strategy | Type | Edge |
|----------|------|------|
| DCA | Basic | Time-based averaging, no prediction needed |
| Grid | Basic | Price-level mean reversion |
| Risk Parity | Quant | Inverse-volatility weighting across 4 symbols |
| Momentum Rank | Quant | Cross-asset momentum ranking |
| Pair Spread | Quant | GOLD↔USDJPY z-score mean reversion |

## Risk & Regime Enhancements
- Multi-TF Regime (M15+H1+H4) with composite + trading style suggestion
- Adaptive Confidence: drawdown/regime/session/winrate → dynamic threshold
- Absolute drawdown limit (15% from peak → halt)
- Regime-aware SL/TP + lot sizing
- `worst_case` property on every strategy

## Pre/Post-Trade Transparency
- Pre-trade snapshot: balance, regime, indicators, risk checks, AI sentiment
- Post-trade analysis: exit reason (SL/TP/manual), duration, regime comparison
- Enhanced Telegram alerts with exit analysis + daily summary + streak alerts

## Frontend
- Settings: Decision Mode + strategy selector with worst_case
- Dashboard: drawdown gauge + multi-TF regime badges + style
- History: trade reason column
- Backtest: all 10 strategies with param grids

## Test plan
- [x] Backend: 401 tests pass (`pytest tests/ -v --no-cov`)
- [x] Frontend: `npx tsc --noEmit` clean
- [ ] Manual: select DCA/Grid strategy → verify signals
- [ ] Manual: select pair_spread on GOLD → verify z-score signals
- [ ] Manual: verify AI dashboard shows analysis but does NOT execute trades
- [ ] Manual: verify drawdown gauge on dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)