### PR TITLE
Fix AI Autonomous mode persistence + regime detection

### DIFF
--- a/backend/app/api/routes/bot.py
+++ b/backend/app/api/routes/bot.py
@@ -183,10 +183,11 @@ async def update_strategy(data: StrategyUpdate):
     engine = _get_engine(data.symbol)
     if data.name == "ai_autonomous":
         settings.trading_mode = "ai_autonomous"
-        engine.strategy = None
+        await engine.redis.set("trading_mode", "ai_autonomous")
         return {"status": "updated", "strategy": "ai_autonomous", "symbol": engine.symbol}
     # Switch back to strategy-first mode
     settings.trading_mode = "strategy"
+    await engine.redis.set("trading_mode", "strategy")
     try:
         await engine.update_strategy(data.name, data.params)
         return {"status": "updated", "strategy": data.name, "symbol": engine.symbol}

--- a/backend/app/bot/engine.py
+++ b/backend/app/bot/engine.py
@@ -252,6 +252,36 @@ class BotEngine:
             "sentiment": sentiment,
         }
 
+    async def _detect_regime(self):
+        """Detect market regime (can be called independently of process_candle)."""
+        try:
+            from app.strategy.regime import detect_multi_tf_regime, HMMRegimeDetector
+            self._multi_tf_regime = await detect_multi_tf_regime(self.market_data, self.symbol)
+            regime_label = self._multi_tf_regime.composite
+
+            try:
+                if not hasattr(self, "_hmm_detector"):
+                    self._hmm_detector = HMMRegimeDetector(n_states=2)
+                ohlcv = await self.market_data.get_ohlcv(self.symbol, self.timeframe, 200)
+                if ohlcv is not None and len(ohlcv) > 100:
+                    prices = ohlcv["close"].values
+                    if not self._hmm_detector._fitted:
+                        self._hmm_detector.fit(prices)
+                    if self._hmm_detector._fitted:
+                        hmm_result = self._hmm_detector.predict(prices)
+                        regime_label = hmm_result.label
+                        self._last_hmm_probs = hmm_result.probabilities
+            except Exception as e:
+                logger.debug(f"HMM overlay unavailable [{self.symbol}]: {e}")
+
+            self.risk_manager.set_regime(regime_label)
+            self._last_regime = regime_label
+            regime_cache = self._multi_tf_regime.to_dict()
+            regime_cache["hmm_probs"] = getattr(self, "_last_hmm_probs", None)
+            await self.redis.setex(f"mtf_regime:{self.symbol}", 300, json.dumps(regime_cache))
+        except Exception as e:
+            logger.warning(f"Regime detection failed [{self.symbol}]: {e}")
+
     async def process_candle(self):
         """Main trading logic — called every candle close."""
         # Auto-recovery: check if paused bot can resume after cooldown
@@ -281,36 +311,7 @@ class BotEngine:
                 return
 
             # 1b. Multi-timeframe regime detection + HMM overlay
-            try:
-                from app.strategy.regime import detect_multi_tf_regime, HMMRegimeDetector
-                self._multi_tf_regime = await detect_multi_tf_regime(self.market_data, self.symbol)
-                regime_label = self._multi_tf_regime.composite
-
-                # HMM regime overlay — refine with probability distribution
-                try:
-                    if not hasattr(self, "_hmm_detector"):
-                        self._hmm_detector = HMMRegimeDetector(n_states=2)
-                    ohlcv = await self.market_data.get_ohlcv(self.symbol, self.timeframe, 200)
-                    if ohlcv is not None and len(ohlcv) > 100:
-                        prices = ohlcv["close"].values
-                        if not self._hmm_detector._fitted:
-                            self._hmm_detector.fit(prices)
-                        if self._hmm_detector._fitted:
-                            hmm_result = self._hmm_detector.predict(prices)
-                            regime_label = hmm_result.label
-                            self._last_hmm_probs = hmm_result.probabilities
-                            logger.debug(f"HMM [{self.symbol}]: {hmm_result.label} probs={hmm_result.probabilities}")
-                except Exception as e:
-                    logger.debug(f"HMM overlay unavailable [{self.symbol}]: {e}")
-
-                self.risk_manager.set_regime(regime_label)
-                self._last_regime = regime_label
-                # Cache for dashboard
-                regime_cache = self._multi_tf_regime.to_dict()
-                regime_cache["hmm_probs"] = getattr(self, "_last_hmm_probs", None)
-                await self.redis.setex(f"mtf_regime:{self.symbol}", 300, json.dumps(regime_cache))
-            except Exception as e:
-                logger.warning(f"Multi-TF regime detection failed: {e}")
+            await self._detect_regime()
 
             # 1c. Check macro event proximity — reduce exposure or skip
             from app.constants import EVENT_BLOCK_HOURS
@@ -461,6 +462,9 @@ class BotEngine:
 
     async def _generate_signal(self) -> tuple[int, str, "pd.DataFrame"] | None:
         """Fetch OHLCV, calculate strategy, apply MTF filter. Returns (signal, label, df) or None."""
+        if self.strategy is None:
+            return None  # AI Autonomous mode — signals come from AI agent, not strategy
+
         df = await self.market_data.get_ohlcv(self.symbol, self.timeframe, DEFAULT_OHLCV_BARS)
         if df.empty:
             return None

--- a/backend/app/bot/scheduler.py
+++ b/backend/app/bot/scheduler.py
@@ -294,7 +294,26 @@ class BotScheduler:
     async def _candle_job(self, symbols: list[str]):
         logger.debug(f"Candle job triggered for {symbols}")
 
+        # Read trading_mode from Redis (survives redeploy), fallback to settings/env
         trading_mode = getattr(settings, "trading_mode", "strategy")
+        try:
+            first_engine = next(iter(self._engines.values()), None)
+            if first_engine and first_engine.redis:
+                cached_mode = await first_engine.redis.get("trading_mode")
+                if cached_mode:
+                    trading_mode = cached_mode if isinstance(cached_mode, str) else cached_mode.decode()
+                    settings.trading_mode = trading_mode
+        except Exception:
+            pass
+
+        # Run regime detection for all running engines (needed in both modes)
+        for sym in symbols:
+            engine = self._engines.get(sym)
+            if engine and engine.state.value == "RUNNING":
+                try:
+                    await engine._detect_regime()
+                except Exception as e:
+                    logger.debug(f"Regime detection [{sym}]: {e}")
 
         if trading_mode == "strategy":
             # Strategy-first: rule-based strategies generate signals, AI is filter only

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -166,6 +166,16 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             logger.warning(f"Prompt registry init failed: {e}")
 
+    # Restore trading_mode from Redis (survives redeploy)
+    try:
+        cached_mode = await redis_client.get("trading_mode")
+        if cached_mode:
+            mode = cached_mode if isinstance(cached_mode, str) else cached_mode.decode()
+            settings.trading_mode = mode
+            logger.info(f"Restored trading_mode from Redis: {mode}")
+    except Exception:
+        pass
+
     # Start scheduler
     scheduler = BotScheduler(manager)
     scheduler.set_health_monitor(health_monitor)


### PR DESCRIPTION
## Summary
- **Persist trading_mode in Redis** — survives Railway redeploy (was in-memory only, lost on restart)
- **Fix regime stuck on "Normal"** — extract `_detect_regime()` into standalone method, call in both strategy and AI autonomous modes
- **Guard strategy=None crash** — prevent `AttributeError` when trading_mode reverts but strategy object is still None

## Test plan
- [ ] Select AI Autonomous in Settings → redeploy → verify trading_mode is still ai_autonomous
- [ ] Check regime badge updates from "Normal" to actual regime after a few candles
- [ ] Start bot → verify Telegram notification is sent
- [ ] Switch back to ema_crossover → verify strategy-first mode works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)