### PR TITLE
Address PR #3 review findings

### DIFF
--- a/backend/app/api/routes/bot.py
+++ b/backend/app/api/routes/bot.py
@@ -9,6 +9,8 @@ from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
+from loguru import logger
+
 from app.auth import require_auth
 from app.config import settings
 from sqlalchemy import desc, select
@@ -184,16 +186,16 @@ async def update_strategy(data: StrategyUpdate):
     if data.name == "ai_autonomous":
         try:
             await engine.redis.set("trading_mode", "ai_autonomous")
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Redis trading_mode write failed: {e}")
         settings.trading_mode = "ai_autonomous"
         engine.strategy = None
         return {"status": "updated", "strategy": "ai_autonomous", "symbol": engine.symbol}
     # Switch back to strategy-first mode
     try:
         await engine.redis.set("trading_mode", "strategy")
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"Redis trading_mode write failed: {e}")
     settings.trading_mode = "strategy"
     try:
         await engine.update_strategy(data.name, data.params)

--- a/backend/app/api/routes/bot.py
+++ b/backend/app/api/routes/bot.py
@@ -182,12 +182,19 @@ async def get_account():
 async def update_strategy(data: StrategyUpdate):
     engine = _get_engine(data.symbol)
     if data.name == "ai_autonomous":
+        try:
+            await engine.redis.set("trading_mode", "ai_autonomous")
+        except Exception:
+            pass
         settings.trading_mode = "ai_autonomous"
-        await engine.redis.set("trading_mode", "ai_autonomous")
+        engine.strategy = None
         return {"status": "updated", "strategy": "ai_autonomous", "symbol": engine.symbol}
     # Switch back to strategy-first mode
+    try:
+        await engine.redis.set("trading_mode", "strategy")
+    except Exception:
+        pass
     settings.trading_mode = "strategy"
-    await engine.redis.set("trading_mode", "strategy")
     try:
         await engine.update_strategy(data.name, data.params)
         return {"status": "updated", "strategy": data.name, "symbol": engine.symbol}

--- a/backend/app/bot/engine.py
+++ b/backend/app/bot/engine.py
@@ -287,6 +287,7 @@ class BotEngine:
         """Main trading logic — called every candle close."""
         # Skip if in AI autonomous mode (AI agent handles trading)
         if settings.trading_mode == "ai_autonomous" or self.strategy is None:
+            logger.debug(f"process_candle skipped [{self.symbol}]: mode={settings.trading_mode}, strategy={'None' if self.strategy is None else self.strategy.name}")
             return
 
         # Auto-recovery: check if paused bot can resume after cooldown

--- a/backend/app/bot/engine.py
+++ b/backend/app/bot/engine.py
@@ -271,6 +271,7 @@ class BotEngine:
                         hmm_result = self._hmm_detector.predict(prices)
                         regime_label = hmm_result.label
                         self._last_hmm_probs = hmm_result.probabilities
+                        logger.debug(f"HMM [{self.symbol}]: {hmm_result.label} probs={hmm_result.probabilities}")
             except Exception as e:
                 logger.debug(f"HMM overlay unavailable [{self.symbol}]: {e}")
 
@@ -284,6 +285,10 @@ class BotEngine:
 
     async def process_candle(self):
         """Main trading logic — called every candle close."""
+        # Skip if in AI autonomous mode (AI agent handles trading)
+        if settings.trading_mode == "ai_autonomous" or self.strategy is None:
+            return
+
         # Auto-recovery: check if paused bot can resume after cooldown
         if self.state == BotState.PAUSED:
             if await self.circuit_breaker.can_resume():

--- a/backend/app/bot/scheduler.py
+++ b/backend/app/bot/scheduler.py
@@ -301,14 +301,14 @@ class BotScheduler:
             if first_engine and first_engine.redis:
                 cached_mode = await first_engine.redis.get("trading_mode")
                 if cached_mode:
-                    trading_mode = cached_mode if isinstance(cached_mode, str) else cached_mode.decode()
-                    settings.trading_mode = trading_mode
+                    cached = cached_mode if isinstance(cached_mode, str) else cached_mode.decode()
+                    if cached in ("strategy", "ai_autonomous"):
+                        trading_mode = cached
+                        settings.trading_mode = cached
+                    else:
+                        logger.warning(f"Invalid trading_mode in Redis: '{cached}', ignoring")
         except Exception as e:
             logger.debug(f"Redis trading_mode read failed: {e}")
-
-        if trading_mode not in ("strategy", "ai_autonomous"):
-            logger.warning(f"Invalid trading_mode '{trading_mode}', defaulting to 'strategy'")
-            trading_mode = "strategy"
 
         if trading_mode == "strategy":
             # Strategy-first: rule-based strategies generate signals, AI is filter only
@@ -431,7 +431,7 @@ class BotScheduler:
         logger.info("Weekly optimization triggered")
         # Run optimization on first engine that has an optimizer
         for engine in self._engines.values():
-            if not engine._optimizer:
+            if not engine._optimizer or engine.strategy is None:
                 continue
             try:
                 result = await engine._optimizer.optimize(engine.strategy.get_params())

--- a/backend/app/bot/scheduler.py
+++ b/backend/app/bot/scheduler.py
@@ -303,20 +303,16 @@ class BotScheduler:
                 if cached_mode:
                     trading_mode = cached_mode if isinstance(cached_mode, str) else cached_mode.decode()
                     settings.trading_mode = trading_mode
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Redis trading_mode read failed: {e}")
 
-        # Run regime detection for all running engines (needed in both modes)
-        for sym in symbols:
-            engine = self._engines.get(sym)
-            if engine and engine.state.value == "RUNNING":
-                try:
-                    await engine._detect_regime()
-                except Exception as e:
-                    logger.debug(f"Regime detection [{sym}]: {e}")
+        if trading_mode not in ("strategy", "ai_autonomous"):
+            logger.warning(f"Invalid trading_mode '{trading_mode}', defaulting to 'strategy'")
+            trading_mode = "strategy"
 
         if trading_mode == "strategy":
             # Strategy-first: rule-based strategies generate signals, AI is filter only
+            # (process_candle runs _detect_regime internally)
             for sym in symbols:
                 engine = self._engines.get(sym)
                 if engine and engine.state.value == "RUNNING":
@@ -327,7 +323,14 @@ class BotScheduler:
             # AI analysis in parallel (for dashboard display, not trading)
             asyncio.create_task(self._run_ai_agent(symbols))
         else:
-            # AI autonomous: AI agent is the primary decision-maker
+            # AI autonomous: run regime detection (process_candle is skipped)
+            for sym in symbols:
+                engine = self._engines.get(sym)
+                if engine and engine.state.value == "RUNNING":
+                    try:
+                        await engine._detect_regime()
+                    except Exception as e:
+                        logger.debug(f"Regime detection [{sym}]: {e}")
             await self._run_ai_agent(symbols)
 
     async def _sentiment_job(self):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -171,10 +171,11 @@ async def lifespan(app: FastAPI):
         cached_mode = await redis_client.get("trading_mode")
         if cached_mode:
             mode = cached_mode if isinstance(cached_mode, str) else cached_mode.decode()
-            settings.trading_mode = mode
-            logger.info(f"Restored trading_mode from Redis: {mode}")
-    except Exception:
-        pass
+            if mode in ("strategy", "ai_autonomous"):
+                settings.trading_mode = mode
+                logger.info(f"Restored trading_mode from Redis: {mode}")
+    except Exception as e:
+        logger.debug(f"Redis trading_mode restore failed: {e}")
 
     # Start scheduler
     scheduler = BotScheduler(manager)


### PR DESCRIPTION
## Summary
- Fix double regime detection in strategy mode (now only runs in AI autonomous branch)
- Restore `engine.strategy = None` + add `trading_mode` guard at top of `process_candle`
- Wrap Redis writes in try/except, validate cached trading_mode values
- Restore HMM debug log, replace bare `except` with `logger.debug`

Addresses all 7 issues from PR #3 code review.

## Test plan
- [ ] Strategy mode: verify regime detection runs once per candle (not twice)
- [ ] AI Autonomous mode: verify regime updates from "Normal"
- [ ] Switch modes: verify no crash when strategy=None
- [ ] Redis down: verify graceful fallback on Redis write failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)