### PR TITLE
Guard strategy=None in strategy and optimization routes

### DIFF
--- a/backend/app/api/routes/ai_insights.py
+++ b/backend/app/api/routes/ai_insights.py
@@ -90,6 +90,8 @@ async def run_optimization():
     bot = _get_engine()
     if not hasattr(bot, "_optimizer") or bot._optimizer is None:
         raise HTTPException(status_code=503, detail="Optimizer not configured")
+    if bot.strategy is None:
+        raise HTTPException(status_code=400, detail="Cannot optimize in AI Autonomous mode — select a strategy first")
     result = await bot._optimizer.optimize(bot.strategy.get_params())
     if result is None:
         raise HTTPException(status_code=500, detail="Optimization failed")
@@ -109,6 +111,8 @@ async def apply_optimization(log_id: int, db: AsyncSession = Depends(get_db)):
 
     import json
     suggested = json.loads(log.suggested_params)
+    if bot.strategy is None:
+        raise HTTPException(status_code=400, detail="Cannot apply optimization in AI Autonomous mode")
     await bot.update_strategy(bot.strategy.name, suggested)
     log.applied = True
     await db.commit()

--- a/backend/app/api/routes/strategy.py
+++ b/backend/app/api/routes/strategy.py
@@ -26,6 +26,8 @@ async def get_available_strategies():
 @router.get("/current")
 async def get_current_strategy():
     bot = _get_engine()
+    if bot.strategy is None:
+        return {"name": "ai_autonomous", "params": {}}
     return {
         "name": bot.strategy.name,
         "params": bot.strategy.get_params(),


### PR DESCRIPTION
## Summary
- Fix 500 crash on `/api/strategy/current` when AI Autonomous mode active — return `ai_autonomous` instead of crashing
- Fix 500 crash on `/api/optimization/run` — return 400 with clear error message
- Fix 500 crash on `/api/optimization/{id}/apply` — same guard

## Test plan
- [ ] Set AI Autonomous in Settings → open Backtest page → no CORS/500 error
- [ ] Set AI Autonomous → click Run Optimization on Insights → see "select a strategy first" error instead of crash
- [ ] Switch back to ema_crossover → both endpoints work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)