### PR TITLE
Fix API action crashes — datetime, symbol alias, error handling

### DIFF
--- a/backend/app/ai/strategy_optimizer.py
+++ b/backend/app/ai/strategy_optimizer.py
@@ -62,7 +62,7 @@ class StrategyOptimizer:
         self._collector = collector
 
     async def build_performance_summary(self, days: int = 7) -> str:
-        cutoff = datetime.now(UTC) - timedelta(days=days)
+        cutoff = datetime.utcnow() - timedelta(days=days)
         result = await self.db.execute(
             select(Trade).where(Trade.open_time >= cutoff).order_by(Trade.open_time)
         )
@@ -173,8 +173,9 @@ Profit factor: {pf:.2f}"""
             # Load last 90 days of data from DB
             to_date = datetime.now(UTC).strftime("%Y-%m-%d")
             from_date = (datetime.now(UTC) - timedelta(days=90)).strftime("%Y-%m-%d")
+            from app.config import resolve_broker_symbol
             df = await self._collector.load_from_db(
-                settings.symbol, settings.timeframe, from_date, to_date
+                resolve_broker_symbol(settings.symbol), settings.timeframe, from_date, to_date
             )
             if df.empty or len(df) < 200:
                 logger.info("Not enough historical data for backtest validation")

--- a/backend/app/ai/strategy_optimizer.py
+++ b/backend/app/ai/strategy_optimizer.py
@@ -130,7 +130,7 @@ Profit factor: {pf:.2f}"""
                     f"apply={should_apply}"
                 )
 
-        now = datetime.now(UTC)
+        now = datetime.utcnow()
         period_start = now - timedelta(days=7)
 
         # Save to DB

--- a/backend/app/api/routes/macro.py
+++ b/backend/app/api/routes/macro.py
@@ -31,7 +31,9 @@ async def get_latest_macro():
 async def get_correlations(days: int = 90):
     if _macro_service is None:
         raise HTTPException(status_code=503, detail="Macro service not initialized")
-    return await _macro_service.compute_correlations(settings.symbol, settings.timeframe, days)
+    from app.config import resolve_broker_symbol
+    symbol = resolve_broker_symbol(settings.symbol)
+    return await _macro_service.compute_correlations(symbol, settings.timeframe, days)
 
 
 @router.get("/events")

--- a/backend/app/data/macro.py
+++ b/backend/app/data/macro.py
@@ -132,7 +132,7 @@ class MacroDataService:
         """Compute rolling correlation between gold price and macro series."""
         from app.db.models import OHLCVData
 
-        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+        cutoff = datetime.utcnow() - timedelta(days=days)
 
         # Get daily gold closes
         result = await self.db.execute(

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -192,13 +192,11 @@ export default function DashboardPage() {
   const handleStop = async () => { setActionLoading("stop"); try { await stopBot(activeSymbol); await fetchData(); } finally { setActionLoading(null); } };
   const handleEmergencyStop = async () => {
     if (confirm("Are you sure? This will close ALL positions for " + activeSymbol + " immediately.")) {
-      await emergencyStop(activeSymbol);
-      fetchData();
+      try { await emergencyStop(activeSymbol); await fetchData(); } catch { /* handled by axios interceptor */ }
     }
   };
   const handleAIFilterToggle = async (enabled: boolean) => {
-    await updateSettings({ symbol: activeSymbol, use_ai_filter: enabled });
-    fetchData();
+    try { await updateSettings({ symbol: activeSymbol, use_ai_filter: enabled }); await fetchData(); } catch { /* handled by axios interceptor */ }
   };
 
   const [chartTimeframe, setChartTimeframe] = useState("M5");

--- a/frontend/app/insights/page.tsx
+++ b/frontend/app/insights/page.tsx
@@ -70,8 +70,7 @@ export default function InsightsPage() {
   };
   const handleApply = async (logId: number) => {
     if (confirm("Apply suggested parameters?")) {
-      await applyOptimization(logId);
-      fetchData();
+      try { await applyOptimization(logId); await fetchData(); } catch { /* handled by axios interceptor */ }
     }
   };
 

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -128,9 +128,11 @@ export default function SettingsPage() {
   };
 
   const handleSettingChange = async (symbol: string, updates: Record<string, unknown>) => {
-    await updateSettings({ symbol, ...updates });
-    const res = await getBotStatus().catch(() => null);
-    if (res?.data?.symbols) setSymbolStatuses(res.data.symbols);
+    try {
+      await updateSettings({ symbol, ...updates });
+      const res = await getBotStatus().catch(() => null);
+      if (res?.data?.symbols) setSymbolStatuses(res.data.symbols);
+    } catch { /* handled by axios interceptor */ }
   };
 
   if (loading) {
@@ -288,9 +290,11 @@ export default function SettingsPage() {
                         value={st.strategy || "ai_autonomous"}
                         onValueChange={async (v) => {
                           if (!v) return;
-                          await updateStrategy(v, undefined, symbol || undefined);
-                          const res = await getBotStatus().catch(() => null);
-                          if (res?.data?.symbols) setSymbolStatuses(res.data.symbols);
+                          try {
+                            await updateStrategy(v, undefined, symbol || undefined);
+                            const res = await getBotStatus().catch(() => null);
+                            if (res?.data?.symbols) setSymbolStatuses(res.data.symbols);
+                          } catch { /* handled by axios interceptor */ }
                         }}
                       >
                         <SelectTrigger className="h-8 text-xs"><SelectValue /></SelectTrigger>


### PR DESCRIPTION
## Summary
Full audit of all API action buttons across the system. Fixes:

**Backend (3 crash bugs):**
- `macro.py`: `datetime.now(timezone.utc)` → `datetime.utcnow()` for DB queries (asyncpg crash)
- `macro.py`: Add `resolve_broker_symbol()` for correlations endpoint
- `strategy_optimizer.py`: Same datetime fix + symbol resolution

**Frontend (4 missing error handlers):**
- Dashboard: Emergency stop — no try/catch
- Insights: Apply optimization — no try/catch
- Settings: Strategy change — no try/catch
- Settings: All setting updates (paper trade, timeframe, lot, risk) — no try/catch

**Reviewed and OK (no changes needed):**
- Backtest 6 operations — already have try/catch/finally
- ML 5 operations — already have try/catch/finally
- Integration test buttons — errors shown in modal
- History export — local operation

## Test plan
- [ ] Open Macro page → no CORS/500 error on correlations
- [ ] Click Emergency Stop → no UI crash on API error
- [ ] Change strategy in Settings → no silent failure
- [ ] Toggle paper trade → change reflected without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)