### PR TITLE
security(api): auth hardening + lot cap + rollout enforcement

### DIFF
--- a/backend/app/api/routes/bot.py
+++ b/backend/app/api/routes/bot.py
@@ -71,8 +71,8 @@ class SettingsUpdate(BaseModel):
     max_risk_per_trade: float | None = Field(None, ge=0.001, le=0.10)
     max_daily_loss: float | None = Field(None, ge=0.01, le=0.20)
     max_concurrent_trades: int | None = Field(None, ge=1, le=20)
-    max_lot: float | None = Field(None, ge=0.01, le=100.0)
-    fixed_lot: float | None = Field(None, ge=0.01, le=100.0)
+    max_lot: float | None = Field(None, ge=0.01, le=1.0)
+    fixed_lot: float | None = Field(None, ge=0.01, le=1.0)
     lot_mode: Literal["fixed", "auto"] | None = None
 
 

--- a/backend/app/api/routes/jobs.py
+++ b/backend/app/api/routes/jobs.py
@@ -1,5 +1,6 @@
 """Job Management API — create, list, cancel, retry jobs."""
 
+from app.auth import require_auth
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -60,7 +61,7 @@ def _get_job_queue(request: Request):
 # ─── Endpoints ────────────────────────────────────────────────────────────────
 
 
-@router.post("")
+@router.post("", dependencies=[Depends(require_auth)])
 async def create_job(
     req: JobCreateRequest,
     request: Request,
@@ -81,7 +82,7 @@ async def create_job(
     return _job_to_response(job)
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(require_auth)])
 async def list_jobs(
     request: Request,
     status: str | None = None,
@@ -110,7 +111,7 @@ async def list_jobs(
     return [_job_to_response(j) for j in jobs]
 
 
-@router.get("/{job_id}")
+@router.get("/{job_id}", dependencies=[Depends(require_auth)])
 async def get_job(job_id: int, request: Request):
     """Get job detail including agent output.
 
@@ -153,7 +154,7 @@ async def get_job(job_id: int, request: Request):
     return _job_to_response(job)
 
 
-@router.post("/{job_id}/cancel")
+@router.post("/{job_id}/cancel", dependencies=[Depends(require_auth)])
 async def cancel_job(
     job_id: int,
     request: Request,
@@ -173,7 +174,7 @@ async def cancel_job(
     return _job_to_response(job)
 
 
-@router.post("/{job_id}/retry")
+@router.post("/{job_id}/retry", dependencies=[Depends(require_auth)])
 async def retry_job(
     job_id: int,
     request: Request,

--- a/backend/app/api/routes/rollout.py
+++ b/backend/app/api/routes/rollout.py
@@ -2,6 +2,7 @@
 
 import os
 
+from app.auth import require_auth
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -49,7 +50,7 @@ async def _resolve_mode(request: Request) -> str:
 # ─── Rollout Mode ────────────────────────────────────────────────────────────
 
 
-@router.get("/mode")
+@router.get("/mode", dependencies=[Depends(require_auth)])
 async def get_rollout_mode(request: Request):
     """Get current rollout mode."""
     mode = await _resolve_mode(request)
@@ -62,7 +63,7 @@ async def get_rollout_mode(request: Request):
     }
 
 
-@router.put("/mode")
+@router.put("/mode", dependencies=[Depends(require_auth)])
 async def set_rollout_mode(
     req: RolloutModeRequest,
     request: Request,
@@ -76,6 +77,20 @@ async def set_rollout_mode(
         )
 
     old_mode = os.environ.get("ROLLOUT_MODE", settings.rollout_mode)
+
+    # Enforce sequential transitions: shadow→paper→micro→live
+    valid_transitions = {
+        "shadow": {"paper"},
+        "paper": {"shadow", "micro"},
+        "micro": {"paper", "live"},
+        "live": {"micro"},
+    }
+    if old_mode != req.mode and req.mode not in valid_transitions.get(old_mode, set()):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot jump from '{old_mode}' to '{req.mode}'. Must transition sequentially.",
+        )
+
     os.environ["ROLLOUT_MODE"] = req.mode
 
     # Sync to Redis so both sources agree
@@ -103,7 +118,7 @@ async def set_rollout_mode(
 # ─── Deploy Readiness Check ─────────────────────────────────────────────────
 
 
-@router.get("/readiness")
+@router.get("/readiness", dependencies=[Depends(require_auth)])
 async def check_readiness(request: Request):
     """Check deploy readiness — verifies all required components are configured."""
     checks: list[dict] = []

--- a/backend/app/api/routes/rollout.py
+++ b/backend/app/api/routes/rollout.py
@@ -78,12 +78,12 @@ async def set_rollout_mode(
 
     old_mode = os.environ.get("ROLLOUT_MODE", settings.rollout_mode)
 
-    # Enforce sequential transitions: shadow→paper→micro→live
+    # Enforce sequential transitions (forward) + allow emergency rollback to any lower mode
     valid_transitions = {
         "shadow": {"paper"},
         "paper": {"shadow", "micro"},
-        "micro": {"paper", "live"},
-        "live": {"micro"},
+        "micro": {"shadow", "paper", "live"},
+        "live": {"shadow", "micro"},
     }
     if old_mode != req.mode and req.mode not in valid_transitions.get(old_mode, set()):
         raise HTTPException(

--- a/backend/app/api/routes/runners.py
+++ b/backend/app/api/routes/runners.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 
+from app.auth import require_auth
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -72,7 +73,7 @@ def _get_manager(request: Request):
 # ─── CRUD ─────────────────────────────────────────────────────────────────────
 
 
-@router.post("")
+@router.post("", dependencies=[Depends(require_auth)])
 async def register_runner(
     req: RunnerCreateRequest,
     request: Request,
@@ -95,7 +96,7 @@ async def register_runner(
     return _runner_to_response(runner)
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(require_auth)])
 async def list_runners(request: Request):
     """List all runners with status."""
     manager = _get_manager(request)
@@ -103,7 +104,7 @@ async def list_runners(request: Request):
     return [_runner_to_response(r) for r in runners]
 
 
-@router.get("/{runner_id}")
+@router.get("/{runner_id}", dependencies=[Depends(require_auth)])
 async def get_runner(runner_id: int, request: Request):
     """Get runner detail."""
     manager = _get_manager(request)
@@ -125,7 +126,7 @@ async def get_runner(runner_id: int, request: Request):
     return {**response.model_dump(), "current_jobs": current_jobs}
 
 
-@router.put("/{runner_id}")
+@router.put("/{runner_id}", dependencies=[Depends(require_auth)])
 async def update_runner(
     runner_id: int,
     req: RunnerUpdateRequest,
@@ -152,7 +153,7 @@ async def update_runner(
     return _runner_to_response(runner)
 
 
-@router.delete("/{runner_id}")
+@router.delete("/{runner_id}", dependencies=[Depends(require_auth)])
 async def delete_runner(
     runner_id: int,
     request: Request,
@@ -179,7 +180,7 @@ async def delete_runner(
 # ─── Lifecycle Control ───────────────────────────────────────────────────────
 
 
-@router.post("/{runner_id}/start")
+@router.post("/{runner_id}/start", dependencies=[Depends(require_auth)])
 async def start_runner(
     runner_id: int,
     request: Request,
@@ -201,7 +202,7 @@ async def start_runner(
     return _runner_to_response(runner)
 
 
-@router.post("/{runner_id}/stop")
+@router.post("/{runner_id}/stop", dependencies=[Depends(require_auth)])
 async def stop_runner(
     runner_id: int,
     request: Request,
@@ -221,7 +222,7 @@ async def stop_runner(
     return _runner_to_response(runner)
 
 
-@router.post("/{runner_id}/restart")
+@router.post("/{runner_id}/restart", dependencies=[Depends(require_auth)])
 async def restart_runner(
     runner_id: int,
     request: Request,
@@ -241,7 +242,7 @@ async def restart_runner(
     return _runner_to_response(runner)
 
 
-@router.post("/{runner_id}/kill")
+@router.post("/{runner_id}/kill", dependencies=[Depends(require_auth)])
 async def kill_runner(
     runner_id: int,
     request: Request,
@@ -264,7 +265,7 @@ async def kill_runner(
 # ─── Observability ───────────────────────────────────────────────────────────
 
 
-@router.get("/{runner_id}/logs")
+@router.get("/{runner_id}/logs", dependencies=[Depends(require_auth)])
 async def get_runner_logs(
     runner_id: int,
     request: Request,
@@ -299,7 +300,7 @@ async def get_runner_logs(
     ]
 
 
-@router.get("/{runner_id}/metrics")
+@router.get("/{runner_id}/metrics", dependencies=[Depends(require_auth)])
 async def get_runner_metrics(
     runner_id: int,
     request: Request,
@@ -334,7 +335,7 @@ async def get_runner_metrics(
     ]
 
 
-@router.get("/{runner_id}/jobs")
+@router.get("/{runner_id}/jobs", dependencies=[Depends(require_auth)])
 async def get_runner_jobs(
     runner_id: int,
     request: Request,

--- a/backend/app/api/routes/secrets.py
+++ b/backend/app/api/routes/secrets.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 
 import httpx
+from app.auth import require_auth
 from fastapi import APIRouter, Depends, HTTPException, Request
 from loguru import logger
 from pydantic import BaseModel
@@ -45,7 +46,7 @@ class SecretDetailResponse(SecretResponse):
 # ─── Vault Status ────────────────────────────────────────────────────────────
 
 
-@router.get("/vault-status")
+@router.get("/vault-status", dependencies=[Depends(require_auth)])
 async def get_vault_status():
     """Check if the vault is available (master key configured)."""
     return {"available": vault.is_available}
@@ -54,7 +55,7 @@ async def get_vault_status():
 # ─── List Secrets ────────────────────────────────────────────────────────────
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(require_auth)])
 async def list_secrets(db: AsyncSession = Depends(get_db)):
     """List all non-deleted secrets (no decryption needed)."""
     result = await db.execute(
@@ -81,7 +82,7 @@ async def list_secrets(db: AsyncSession = Depends(get_db)):
 # ─── Get Secret (masked) ────────────────────────────────────────────────────
 
 
-@router.get("/{key}")
+@router.get("/{key}", dependencies=[Depends(require_auth)])
 async def get_secret(
     key: str,
     request: Request,
@@ -119,7 +120,7 @@ async def get_secret(
 # ─── Upsert Secret ──────────────────────────────────────────────────────────
 
 
-@router.put("/{key}")
+@router.put("/{key}", dependencies=[Depends(require_auth)])
 async def upsert_secret(
     key: str,
     req: SecretUpsertRequest,
@@ -171,7 +172,7 @@ async def upsert_secret(
 # ─── Delete Secret (soft) ───────────────────────────────────────────────────
 
 
-@router.delete("/{key}")
+@router.delete("/{key}", dependencies=[Depends(require_auth)])
 async def delete_secret(
     key: str,
     request: Request,
@@ -196,7 +197,7 @@ async def delete_secret(
 # ─── Test Secret Connectivity ───────────────────────────────────────────────
 
 
-@router.post("/{key}/test")
+@router.post("/{key}/test", dependencies=[Depends(require_auth)])
 async def test_secret(
     key: str,
     request: Request,
@@ -237,7 +238,7 @@ async def test_secret(
 # ─── Secret History ──────────────────────────────────────────────────────────
 
 
-@router.get("/{key}/history")
+@router.get("/{key}/history", dependencies=[Depends(require_auth)])
 async def get_secret_history(
     key: str,
     db: AsyncSession = Depends(get_db),

--- a/mt5_bridge/main.py
+++ b/mt5_bridge/main.py
@@ -39,7 +39,10 @@ TIMEFRAMES = {
 
 # --- Auth dependency ---
 async def verify_api_key(x_bridge_key: str = Header(...)):
-    if x_bridge_key != BRIDGE_API_KEY:
+    import hmac
+    if not BRIDGE_API_KEY:
+        raise HTTPException(status_code=503, detail="Bridge API key not configured")
+    if not hmac.compare_digest(x_bridge_key, BRIDGE_API_KEY):
         raise HTTPException(status_code=401, detail="Invalid API key")
 
 

--- a/mt5_bridge/main.py
+++ b/mt5_bridge/main.py
@@ -3,6 +3,7 @@ MT5 Bridge — FastAPI app that runs on Windows VPS only.
 Provides HTTP API to interact with MetaTrader 5.
 """
 
+import hmac
 import os
 from datetime import datetime, timedelta
 from enum import Enum
@@ -39,7 +40,6 @@ TIMEFRAMES = {
 
 # --- Auth dependency ---
 async def verify_api_key(x_bridge_key: str = Header(...)):
-    import hmac
     if not BRIDGE_API_KEY:
         raise HTTPException(status_code=503, detail="Bridge API key not configured")
     if not hmac.compare_digest(x_bridge_key, BRIDGE_API_KEY):


### PR DESCRIPTION
## Summary
Full security audit findings — fixes 4 CRITICAL + 1 HIGH vulnerability:

- **27 endpoints** were completely unauthenticated (secrets vault, runners, jobs, rollout)
- `max_lot` allowed 100 lots via API (guardrails only cap at 1.0 for AI path)
- Rollout mode could jump directly from shadow → live
- MT5 Bridge accepted empty API key as valid

## Changes
| File | Fix |
|------|-----|
| secrets.py | `require_auth` on all 7 endpoints |
| runners.py | `require_auth` on all 12 endpoints |
| jobs.py | `require_auth` on all 5 endpoints |
| rollout.py | `require_auth` on 3 endpoints + sequential transition validation |
| bot.py | Cap `max_lot`/`fixed_lot` from 100.0 → 1.0 |
| mt5_bridge/main.py | Reject empty API key + `hmac.compare_digest` |

## Test plan
- [ ] Verify all secrets/runners/jobs/rollout endpoints return 401 without token
- [ ] Verify `PUT /api/bot/settings` rejects `max_lot > 1.0`
- [ ] Verify rollout mode rejects shadow → live (must go shadow → paper → micro → live)
- [ ] Verify MT5 Bridge rejects requests when `BRIDGE_API_KEY` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)