### PR TITLE
feat: composite overfitting score for AI agent + frontend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Frontend (Next.js 16) → Backend (FastAPI) → MT5 Bridge (Windows VPS)
   - `strategy/` — 5 strategies + ensemble + MTF filter + regime detection
   - `risk/` — risk manager, circuit breaker, correlation filter
   - `ml/` — LightGBM trainer, features (40+), predictor, drift detection, sentiment features
-  - `backtest/` — engine, optimizer, walk_forward, monte_carlo
+  - `backtest/` — engine, optimizer, walk_forward, monte_carlo, overfitting (composite score)
   - `data/` — collector, macro data, macro events
   - `news/` — news fetcher + sources
   - `notifications/` — Telegram alerts
@@ -60,7 +60,7 @@ Frontend (Next.js 16) → Backend (FastAPI) → MT5 Bridge (Windows VPS)
   - `logging_config.py` — structured JSON logging
 - `backend/mcp_server/` — MCP Agent system (Claude Code SDK)
   - `agents/` — orchestrator, technical/fundamental/risk analysts, reflector, prompt_registry
-  - `tools/` — 12 tool modules (broker, market_data, indicators, risk, portfolio, sentiment, history, journal, learning, session, strategy_gen, memory)
+  - `tools/` — 13 tool modules (broker, market_data, indicators, risk, portfolio, sentiment, history, journal, learning, session, strategy_gen, memory, overfitting)
   - `guardrails.py` — non-bypassable trading limits at broker tool level
   - `sdk_client.py` — Claude Code SDK client
   - `server.py` — MCP server entry
@@ -86,7 +86,7 @@ Frontend (Next.js 16) → Backend (FastAPI) → MT5 Bridge (Windows VPS)
   - `lib/websocket.ts` — WS client with token auth
 - `mt5_bridge/` — FastAPI on Windows VPS (MetaTrader5 SDK)
 - `scripts/backup_db.sh` — daily pg_dump
-- `backend/tests/` — 403 tests across 25 test files (unit + integration)
+- `backend/tests/` — 429 tests across 26 test files (unit + integration)
 - `Dockerfile.trading-agent` — Python 3.11-slim agent image
 
 ## Tech Stack

--- a/backend/app/api/routes/backtest.py
+++ b/backend/app/api/routes/backtest.py
@@ -5,19 +5,18 @@ Backtest API routes.
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException
+from loguru import logger
+from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import require_auth
-from app.db.models import NewsSentiment
-from app.db.session import get_db
-from pydantic import BaseModel, Field
-
 from app.backtest.engine import BacktestEngine
 from app.backtest.monte_carlo import monte_carlo_analysis
 from app.backtest.optimizer import grid_search
 from app.backtest.walk_forward import walk_forward_test
-from app.config import Settings
+from app.db.models import NewsSentiment
+from app.db.session import get_db
 from app.risk.manager import RiskManager
 from app.strategy import get_strategy
 
@@ -282,6 +281,7 @@ class PermutationTestRequest(BaseModel):
 async def run_permutation_test_endpoint(req: PermutationTestRequest):
     """Test if strategy signals are significantly better than random."""
     import asyncio
+
     from app.backtest.statistical_tests import permutation_test
 
     df = await _load_data(req.symbol, req.source, req.timeframe, req.count, req.from_date, req.to_date)
@@ -300,3 +300,110 @@ async def run_permutation_test_endpoint(req: PermutationTestRequest):
         include_costs=req.include_costs,
     )
     return {**result.to_dict(), "symbol": req.symbol, "strategy": req.strategy}
+
+
+# ─── Composite Overfitting Score ────────────────────────────────────────────
+
+
+class OverfittingScoreRequest(BaseModel):
+    strategy: str = "ema_crossover"
+    params: dict | None = None
+    symbol: str = "GOLD"
+    timeframe: str = "M15"
+    source: str = "db"
+    count: int = Field(5000, ge=500, le=50000)
+    from_date: str | None = None
+    to_date: str | None = None
+    initial_balance: float = Field(10000.0, ge=100.0)
+    risk_per_trade: float = Field(0.01, ge=0.001, le=0.10)
+    max_lot: float = Field(1.0, ge=0.01, le=100.0)
+    n_permutations: int = Field(200, ge=50, le=1000)
+    n_simulations: int = Field(500, ge=100, le=5000)
+    n_splits: int = Field(5, ge=2, le=10)
+    train_pct: float = Field(0.7, ge=0.5, le=0.9)
+
+
+@router.post("/overfitting-score", dependencies=[Depends(require_auth)])
+async def compute_overfitting_score_endpoint(req: OverfittingScoreRequest):
+    """Compute composite overfitting score (0-100%) for a strategy.
+
+    Runs walk-forward, permutation test, and monte carlo concurrently,
+    then combines into a single overfitting percentage with grade.
+    """
+    import asyncio
+
+    from app.backtest.overfitting import auto_param_grid, compute_composite_score
+
+    df = await _load_data(req.symbol, req.source, req.timeframe, req.count, req.from_date, req.to_date)
+    if df.empty:
+        return {"error": "No OHLCV data available"}
+
+    risk_manager = RiskManager(max_risk_per_trade=req.risk_per_trade, max_lot=req.max_lot)
+    param_grid = auto_param_grid(req.strategy)
+
+    # ── Define sub-tasks ────────────────────────────────────────────────
+
+    async def _run_walk_forward():
+        if param_grid is None:
+            return None
+        try:
+            return await asyncio.to_thread(
+                walk_forward_test,
+                strategy_name=req.strategy,
+                df=df,
+                param_grid=param_grid,
+                n_splits=req.n_splits,
+                train_pct=req.train_pct,
+                initial_balance=req.initial_balance,
+                risk_per_trade=req.risk_per_trade,
+                max_lot=req.max_lot,
+            )
+        except Exception as e:
+            logger.error(f"Walk-forward failed: {e}")
+            return None
+
+    async def _run_permutation():
+        try:
+            from app.backtest.statistical_tests import permutation_test
+
+            strategy = get_strategy(req.strategy, req.params, symbol=req.symbol)
+            return await asyncio.to_thread(
+                permutation_test,
+                df, strategy, risk_manager,
+                initial_balance=req.initial_balance,
+                n_permutations=req.n_permutations,
+            )
+        except Exception as e:
+            logger.error(f"Permutation test failed: {e}")
+            return None
+
+    async def _run_monte_carlo():
+        try:
+            strategy = get_strategy(req.strategy, req.params, symbol=req.symbol)
+            engine = BacktestEngine(strategy, risk_manager, req.initial_balance)
+            bt_result = await asyncio.to_thread(engine.run, df)
+            trades = bt_result.to_dict().get("trades", [])
+            profits = [t["profit"] for t in trades if "profit" in t]
+            if len(profits) < 5:
+                return None
+            return await asyncio.to_thread(
+                monte_carlo_analysis, profits, req.n_simulations, req.initial_balance
+            )
+        except Exception as e:
+            logger.error(f"Monte Carlo failed: {e}")
+            return None
+
+    # ── Run concurrently ────────────────────────────────────────────────
+
+    wf_result, perm_result, mc_result = await asyncio.gather(
+        _run_walk_forward(),
+        _run_permutation(),
+        _run_monte_carlo(),
+    )
+
+    result = compute_composite_score(wf_result, perm_result, mc_result)
+    return {
+        **result.to_dict(),
+        "strategy": req.strategy,
+        "symbol": req.symbol,
+    }

--- a/backend/app/backtest/overfitting.py
+++ b/backend/app/backtest/overfitting.py
@@ -1,0 +1,230 @@
+"""
+Composite Overfitting Score — combines walk-forward, permutation test,
+param stability, and monte carlo into a single 0-100% overfitting metric.
+"""
+
+from dataclasses import dataclass, field
+
+import numpy as np
+from loguru import logger
+
+from app.backtest.monte_carlo import MonteCarloResult
+from app.backtest.statistical_tests import PermutationTestResult
+from app.backtest.walk_forward import WalkForwardResult
+
+# ─── Default Weights ────────────────────────────────────────────────────────
+
+DEFAULT_WEIGHTS = {
+    "walk_forward": 0.40,
+    "permutation": 0.25,
+    "param_stability": 0.20,
+    "monte_carlo": 0.15,
+}
+
+# ─── Grade Thresholds ───────────────────────────────────────────────────────
+
+GRADE_HEALTHY = 30.0
+GRADE_MODERATE = 60.0
+
+
+@dataclass
+class OverfittingScoreResult:
+    overfitting_pct: float = 0.0
+    grade: str = "healthy"
+    components: dict = field(default_factory=dict)
+    weights_used: dict = field(default_factory=dict)
+    walk_forward: dict | None = None
+    permutation: dict | None = None
+    monte_carlo: dict | None = None
+    partial: bool = False
+    skipped_tests: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "overfitting_pct": round(self.overfitting_pct, 1),
+            "grade": self.grade,
+            "components": {k: round(v, 1) for k, v in self.components.items()},
+            "weights_used": {k: round(v, 3) for k, v in self.weights_used.items()},
+            "walk_forward": self.walk_forward,
+            "permutation": self.permutation,
+            "monte_carlo": self.monte_carlo,
+            "partial": self.partial,
+            "skipped_tests": self.skipped_tests,
+        }
+
+
+def _clamp(value: float, lo: float = 0.0, hi: float = 100.0) -> float:
+    return max(lo, min(hi, value))
+
+
+def _classify_grade(pct: float) -> str:
+    if pct < GRADE_HEALTHY:
+        return "healthy"
+    if pct < GRADE_MODERATE:
+        return "moderate"
+    return "overfit"
+
+
+def _redistribute_weights(
+    available: dict[str, float],
+    base_weights: dict[str, float] | None = None,
+) -> dict[str, float]:
+    """Redistribute weights proportionally among available components."""
+    weights = base_weights or DEFAULT_WEIGHTS
+    total = sum(weights[k] for k in available)
+    if total <= 0:
+        return {k: 1.0 / len(available) for k in available}
+    return {k: weights[k] / total for k in available}
+
+
+def compute_composite_score(
+    wf_result: WalkForwardResult | None = None,
+    perm_result: PermutationTestResult | None = None,
+    mc_result: MonteCarloResult | None = None,
+) -> OverfittingScoreResult:
+    """Combine multiple overfitting metrics into a single 0-100% score.
+
+    Args:
+        wf_result: Walk-forward test result (provides overfitting_ratio + param_stability)
+        perm_result: Permutation test result (provides p_value)
+        mc_result: Monte Carlo result (provides probability_of_ruin)
+
+    Returns:
+        OverfittingScoreResult with composite percentage and breakdown.
+    """
+    components: dict[str, float] = {}
+    summaries: dict[str, dict | None] = {
+        "walk_forward": None,
+        "permutation": None,
+        "monte_carlo": None,
+    }
+    skipped: list[str] = []
+
+    # ── Walk-Forward component ──────────────────────────────────────────
+    if wf_result and wf_result.n_splits > 0 and wf_result.in_sample_avg_sharpe > 0:
+        # overfitting_ratio = OOS Sharpe / IS Sharpe; 1.0 = perfect, 0.0 = total overfit
+        wf_score = _clamp((1.0 - wf_result.overfitting_ratio) * 100)
+        components["walk_forward"] = wf_score
+
+        # Param stability (CV): 0 = stable, 1+ = unstable
+        if wf_result.param_stability_score is not None:
+            stab_score = _clamp(wf_result.param_stability_score * 100)
+            components["param_stability"] = stab_score
+
+        summaries["walk_forward"] = {
+            "overfitting_ratio": round(wf_result.overfitting_ratio, 4),
+            "likely_overfit": wf_result.likely_overfit,
+            "is_sharpe": round(wf_result.in_sample_avg_sharpe, 4),
+            "oos_sharpe": round(wf_result.aggregate_oos_sharpe, 4),
+            "oos_sharpe_ci": (
+                [round(wf_result.oos_sharpe_ci[0], 4), round(wf_result.oos_sharpe_ci[1], 4)]
+                if wf_result.oos_sharpe_ci else None
+            ),
+            "param_stability_score": (
+                round(wf_result.param_stability_score, 4)
+                if wf_result.param_stability_score is not None else None
+            ),
+            "param_stability_detail": (
+                {k: round(v, 4) for k, v in wf_result.param_stability_detail.items()}
+                if wf_result.param_stability_detail else None
+            ),
+        }
+    else:
+        skipped.append("walk_forward")
+        if not (wf_result and wf_result.param_stability_score is not None):
+            skipped.append("param_stability")
+
+    # ── Permutation component ───────────────────────────────────────────
+    if perm_result and perm_result.n_permutations > 0:
+        # High p-value → strategy does NOT beat random → overfit signal
+        perm_score = _clamp(perm_result.p_value * 200)
+        components["permutation"] = perm_score
+
+        summaries["permutation"] = {
+            "real_sharpe": round(perm_result.real_sharpe, 4),
+            "p_value": round(perm_result.p_value, 4),
+            "is_significant": perm_result.is_significant,
+            "shuffled_mean": round(perm_result.shuffled_mean, 4),
+        }
+    else:
+        skipped.append("permutation")
+
+    # ── Monte Carlo component ───────────────────────────────────────────
+    if mc_result and mc_result.n_simulations > 0:
+        mc_score = _clamp(mc_result.probability_of_ruin * 200)
+        components["monte_carlo"] = mc_score
+
+        summaries["monte_carlo"] = {
+            "probability_of_ruin": round(mc_result.probability_of_ruin, 4),
+            "probability_of_profit": round(mc_result.probability_of_profit, 4),
+            "p95_max_drawdown": round(mc_result.p95_max_drawdown, 4),
+            "median_final_balance": round(mc_result.median_final_balance, 2),
+        }
+    else:
+        skipped.append("monte_carlo")
+
+    # ── Compute weighted composite ──────────────────────────────────────
+    if not components:
+        logger.warning("Overfitting score: no components available")
+        return OverfittingScoreResult(
+            overfitting_pct=0.0,
+            grade="unknown",
+            partial=True,
+            skipped_tests=skipped,
+        )
+
+    weights = _redistribute_weights(components)
+    composite = sum(components[k] * weights[k] for k in components)
+    composite = _clamp(composite)
+
+    logger.info(
+        f"Overfitting score: {composite:.1f}% ({_classify_grade(composite)}) "
+        f"components={list(components.keys())}"
+    )
+
+    return OverfittingScoreResult(
+        overfitting_pct=composite,
+        grade=_classify_grade(composite),
+        components=components,
+        weights_used=weights,
+        walk_forward=summaries["walk_forward"],
+        permutation=summaries["permutation"],
+        monte_carlo=summaries["monte_carlo"],
+        partial=len(skipped) > 0,
+        skipped_tests=skipped,
+    )
+
+
+# ─── Auto param_grid generation ──────────────────────────────────────────────
+
+# Param ranges per strategy — mirrors mcp_server/tools/strategy_gen.STRATEGY_PROFILES
+# but avoids importing app.config (which triggers Settings validation in tests).
+_PARAM_RANGES: dict[str, dict[str, tuple]] = {
+    "ema_crossover": {"fast_period": (5, 50), "slow_period": (20, 200)},
+    "rsi_filter": {"period": (7, 28), "overbought": (65, 85), "oversold": (15, 35)},
+    "breakout": {"lookback": (10, 50)},
+    "mean_reversion": {"bb_period": (10, 30), "bb_std": (1.5, 3.0), "min_bandwidth": (0.005, 0.03)},
+    "ml_signal": {"confidence_threshold": (0.5, 0.9)},
+    # ensemble, dca, grid, etc. have no tunable numeric params for grid search
+}
+
+
+def auto_param_grid(strategy_name: str, n_values: int = 5) -> dict[str, list] | None:
+    """Generate a param_grid from known strategy param ranges.
+
+    Returns None if the strategy has no param_ranges (e.g., ensemble).
+    """
+    ranges = _PARAM_RANGES.get(strategy_name)
+    if not ranges:
+        return None
+
+    grid: dict[str, list] = {}
+    for param, (lo, hi) in ranges.items():
+        if isinstance(lo, int) and isinstance(hi, int):
+            values = np.linspace(lo, hi, n_values)
+            grid[param] = sorted(set(int(round(v)) for v in values))
+        else:
+            values = np.linspace(float(lo), float(hi), n_values)
+            grid[param] = [round(float(v), 4) for v in values]
+
+    return grid if grid else None

--- a/backend/mcp_server/agents/orchestrator.py
+++ b/backend/mcp_server/agents/orchestrator.py
@@ -60,7 +60,10 @@ If you decide to HOLD:
 - NEVER skip logging — every decision must be journaled
 - ALWAYS include all three analyst reports in your reasoning
 - Prefer HOLD when uncertain — missing a trade is better than a bad trade
-- Maximum 3 trades per analysis cycle"""
+- Maximum 3 trades per analysis cycle
+- If Reflector reports overfitting grade "overfit" (>60%): reduce lot size by 50% and note elevated overfitting risk in log_decision
+- If overfitting grade is "moderate" (30-60%): proceed with caution, mention in log_decision
+- Always reference the overfitting grade when making strategy selection decisions"""
 
 # Orchestrator has access to execution tools + journal
 ORCHESTRATOR_TOOL_NAMES = [

--- a/backend/mcp_server/agents/reflector.py
+++ b/backend/mcp_server/agents/reflector.py
@@ -20,7 +20,8 @@ Before each trading session, you review what happened recently and provide conte
 2. Use `detect_regime` to understand the current market state
 3. Use `get_learnings` to recall previous insights
 4. Use `get_context` to check if there's existing session context
-5. Synthesize: What worked? What didn't? What should we watch for?
+5. Use `compute_overfitting_score` to check the recommended strategy's overfitting risk
+6. Synthesize: What worked? What didn't? What should we watch for?
 
 ## Output Format
 Provide a structured reflection with:
@@ -28,7 +29,8 @@ Provide a structured reflection with:
 - **Current Regime**: Market regime and what it means for strategy selection
 - **Lessons**: Top 3 actionable insights from recent trades
 - **Strategy Recommendation**: Which strategy fits the current regime
-- **Warnings**: Any risk factors to watch (losing streak, high volatility, etc.)
+- **Overfitting Check**: Score (%), grade, and key concerns from statistical validation
+- **Warnings**: Any risk factors to watch (losing streak, high volatility, overfitting, etc.)
 - **Session Context**: Key context the orchestrator should know
 
 After your analysis:
@@ -57,6 +59,7 @@ TOOL_NAMES = [
     "save_learning",
     "get_strategy_profiles",
     "recommend_strategy",
+    "compute_overfitting_score",
     "get_memories",
     "save_memory",
     "validate_memory",

--- a/backend/mcp_server/agents/risk_analyst.py
+++ b/backend/mcp_server/agents/risk_analyst.py
@@ -19,6 +19,7 @@ Evaluate whether a proposed trade is safe given current portfolio exposure, acco
 4. Use `validate_trade` to check risk rules
 5. Use `check_correlation` to detect correlated exposure
 6. If a trade is proposed, use `calculate_lot_size` and `calculate_sl_tp` for sizing
+7. Optionally use `compute_overfitting_score` to validate strategy robustness before approving a trade
 
 ## Output Format
 Provide a structured risk assessment with:
@@ -42,6 +43,7 @@ TOOL_NAMES = [
     "check_correlation",
     "calculate_lot_size",
     "calculate_sl_tp",
+    "compute_overfitting_score",
 ]
 
 

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -12,8 +12,21 @@ Usage:
 
 from mcp.server.fastmcp import FastMCP
 
-from mcp_server.tools import market_data, indicators, risk, broker, portfolio, sentiment, history, journal
-from mcp_server.tools import learning, session, strategy_gen, quant
+from mcp_server.tools import (
+    broker,
+    history,
+    indicators,
+    journal,
+    learning,
+    market_data,
+    overfitting,
+    portfolio,
+    quant,
+    risk,
+    sentiment,
+    session,
+    strategy_gen,
+)
 
 
 def create_server() -> FastMCP:
@@ -230,12 +243,28 @@ def create_server() -> FastMCP:
         """Get quantitative signals: momentum (ROC), mean-reversion (z-score), volatility breakout (ATR ratio)."""
         return await quant.get_quant_signals(symbol, timeframe, count)
 
+    # ─── Overfitting Detection Tools ──────────────────────────────────
+
+    @mcp.tool()
+    async def compute_overfitting_score(
+        strategy: str,
+        symbol: str = "GOLD",
+        timeframe: str = "M15",
+        source: str = "db",
+        count: int = 5000,
+    ) -> dict:
+        """Compute composite overfitting score (0-100%) for a strategy.
+        Combines walk-forward ratio, permutation test, param stability, and monte carlo ruin probability."""
+        return await overfitting.compute_overfitting_score(strategy, symbol, timeframe, source, count)
+
     return mcp
 
 
 if __name__ == "__main__":
     import os
+
     import redis.asyncio as redis_async
+
     from mcp_server.tools import init_mcp_tools
 
     redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")

--- a/backend/mcp_server/tools/overfitting.py
+++ b/backend/mcp_server/tools/overfitting.py
@@ -1,0 +1,49 @@
+"""MCP tool for composite overfitting score — wraps /api/backtest/overfitting-score."""
+
+import httpx
+
+from mcp_server.tools import backend_url as _backend_url
+
+
+async def compute_overfitting_score(
+    strategy: str,
+    symbol: str = "GOLD",
+    timeframe: str = "M15",
+    source: str = "db",
+    count: int = 5000,
+) -> dict:
+    """Compute a composite overfitting score (0-100%) for a strategy.
+
+    Runs walk-forward analysis, permutation test, and monte carlo simulation,
+    then combines results into a single overfitting percentage with grade.
+
+    Args:
+        strategy: Strategy name (e.g. "ema_crossover", "breakout", "mean_reversion")
+        symbol: Trading symbol (e.g. "GOLD", "BTCUSD", "USDJPY")
+        timeframe: Candle timeframe (default "M15")
+        source: Data source — "db" (historical) or "mt5" (live)
+        count: Number of candles to use for analysis
+
+    Returns:
+        Dict with overfitting_pct (0-100), grade (healthy/moderate/overfit),
+        component breakdown, and individual test summaries.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=300) as client:
+            resp = await client.post(
+                f"{_backend_url()}/api/backtest/overfitting-score",
+                json={
+                    "strategy": strategy,
+                    "symbol": symbol,
+                    "timeframe": timeframe,
+                    "source": source,
+                    "count": count,
+                },
+            )
+            if resp.status_code == 200:
+                return resp.json()
+            return {"error": f"Backend returned {resp.status_code}: {resp.text}"}
+    except httpx.TimeoutException:
+        return {"error": "Overfitting score computation timed out (>300s)"}
+    except Exception as e:
+        return {"error": f"Failed to compute overfitting score: {e}"}

--- a/backend/tests/unit/test_overfitting_score.py
+++ b/backend/tests/unit/test_overfitting_score.py
@@ -1,0 +1,287 @@
+"""
+Unit tests for composite overfitting score — backend/app/backtest/overfitting.py.
+"""
+
+import pytest
+
+from app.backtest.overfitting import (
+    OverfittingScoreResult,
+    auto_param_grid,
+    compute_composite_score,
+    _clamp,
+    _classify_grade,
+    _redistribute_weights,
+    DEFAULT_WEIGHTS,
+)
+from app.backtest.walk_forward import WalkForwardResult
+from app.backtest.statistical_tests import PermutationTestResult
+from app.backtest.monte_carlo import MonteCarloResult
+
+
+# ─── Helper builders ────────────────────────────────────────────────────────
+
+
+def _make_wf(
+    overfitting_ratio: float = 0.8,
+    is_sharpe: float = 1.5,
+    oos_sharpe: float = 1.2,
+    param_stability_score: float | None = 0.3,
+    n_splits: int = 5,
+) -> WalkForwardResult:
+    return WalkForwardResult(
+        n_splits=n_splits,
+        in_sample_avg_sharpe=is_sharpe,
+        aggregate_oos_sharpe=oos_sharpe,
+        overfitting_ratio=overfitting_ratio,
+        likely_overfit=overfitting_ratio < 0.5,
+        param_stability_score=param_stability_score,
+        param_stability_detail={"fast_period": 0.2, "slow_period": 0.4} if param_stability_score else {},
+        oos_sharpe_ci=(0.8, 1.6) if n_splits >= 3 else None,
+    )
+
+
+def _make_perm(
+    p_value: float = 0.02,
+    real_sharpe: float = 1.2,
+    is_significant: bool = True,
+) -> PermutationTestResult:
+    return PermutationTestResult(
+        real_sharpe=real_sharpe,
+        shuffled_mean=0.1,
+        shuffled_std=0.3,
+        p_value=p_value,
+        is_significant=is_significant,
+        n_permutations=200,
+        significance=0.05,
+    )
+
+
+def _make_mc(
+    ruin_prob: float = 0.05,
+    profit_prob: float = 0.85,
+) -> MonteCarloResult:
+    return MonteCarloResult(
+        n_simulations=500,
+        initial_balance=10000.0,
+        median_final_balance=11500.0,
+        mean_final_balance=11800.0,
+        p5_final_balance=8000.0,
+        p95_final_balance=15000.0,
+        median_max_drawdown=0.08,
+        p95_max_drawdown=0.15,
+        probability_of_ruin=ruin_prob,
+        probability_of_profit=profit_prob,
+    )
+
+
+# ─── _clamp ─────────────────────────────────────────────────────────────────
+
+
+class TestClamp:
+    def test_within_range(self):
+        assert _clamp(50.0) == 50.0
+
+    def test_below_min(self):
+        assert _clamp(-10.0) == 0.0
+
+    def test_above_max(self):
+        assert _clamp(150.0) == 100.0
+
+    def test_at_boundaries(self):
+        assert _clamp(0.0) == 0.0
+        assert _clamp(100.0) == 100.0
+
+
+# ─── _classify_grade ────────────────────────────────────────────────────────
+
+
+class TestClassifyGrade:
+    def test_healthy(self):
+        assert _classify_grade(0.0) == "healthy"
+        assert _classify_grade(29.9) == "healthy"
+
+    def test_moderate(self):
+        assert _classify_grade(30.0) == "moderate"
+        assert _classify_grade(59.9) == "moderate"
+
+    def test_overfit(self):
+        assert _classify_grade(60.0) == "overfit"
+        assert _classify_grade(100.0) == "overfit"
+
+
+# ─── _redistribute_weights ──────────────────────────────────────────────────
+
+
+class TestRedistributeWeights:
+    def test_all_components(self):
+        available = {"walk_forward": 10, "permutation": 5, "param_stability": 3, "monte_carlo": 2}
+        weights = _redistribute_weights(available)
+        assert abs(sum(weights.values()) - 1.0) < 1e-9
+
+    def test_two_components(self):
+        available = {"permutation": 5, "monte_carlo": 2}
+        weights = _redistribute_weights(available)
+        assert abs(sum(weights.values()) - 1.0) < 1e-9
+        # permutation weight should be > monte_carlo weight
+        assert weights["permutation"] > weights["monte_carlo"]
+
+    def test_single_component(self):
+        available = {"permutation": 5}
+        weights = _redistribute_weights(available)
+        assert weights["permutation"] == pytest.approx(1.0)
+
+
+# ─── compute_composite_score ────────────────────────────────────────────────
+
+
+class TestCompositeScore:
+    def test_all_components_healthy(self):
+        """Good WF ratio + significant perm + low ruin = healthy."""
+        result = compute_composite_score(
+            wf_result=_make_wf(overfitting_ratio=0.9, param_stability_score=0.1),
+            perm_result=_make_perm(p_value=0.01),
+            mc_result=_make_mc(ruin_prob=0.02),
+        )
+        assert result.grade == "healthy"
+        assert result.overfitting_pct < 30.0
+        assert not result.partial
+        assert len(result.skipped_tests) == 0
+        assert "walk_forward" in result.components
+        assert "permutation" in result.components
+        assert "param_stability" in result.components
+        assert "monte_carlo" in result.components
+
+    def test_all_components_overfit(self):
+        """Bad WF ratio + not significant + high ruin = overfit."""
+        result = compute_composite_score(
+            wf_result=_make_wf(overfitting_ratio=0.1, param_stability_score=0.9),
+            perm_result=_make_perm(p_value=0.6, is_significant=False),
+            mc_result=_make_mc(ruin_prob=0.6),
+        )
+        assert result.grade == "overfit"
+        assert result.overfitting_pct >= 60.0
+
+    def test_moderate_score(self):
+        """Mixed signals → moderate."""
+        result = compute_composite_score(
+            wf_result=_make_wf(overfitting_ratio=0.5, param_stability_score=0.4),
+            perm_result=_make_perm(p_value=0.04),
+            mc_result=_make_mc(ruin_prob=0.3),
+        )
+        assert result.grade == "moderate"
+        assert 30.0 <= result.overfitting_pct < 60.0
+
+    def test_missing_wf_result(self):
+        """Without WF, weights redistribute to remaining components."""
+        result = compute_composite_score(
+            wf_result=None,
+            perm_result=_make_perm(p_value=0.01),
+            mc_result=_make_mc(ruin_prob=0.02),
+        )
+        assert result.partial
+        assert "walk_forward" in result.skipped_tests
+        assert "param_stability" in result.skipped_tests
+        assert "walk_forward" not in result.components
+        # Should still produce a score
+        assert result.overfitting_pct >= 0.0
+
+    def test_missing_perm_result(self):
+        result = compute_composite_score(
+            wf_result=_make_wf(),
+            perm_result=None,
+            mc_result=_make_mc(),
+        )
+        assert result.partial
+        assert "permutation" in result.skipped_tests
+        assert "permutation" not in result.components
+
+    def test_missing_mc_result(self):
+        result = compute_composite_score(
+            wf_result=_make_wf(),
+            perm_result=_make_perm(),
+            mc_result=None,
+        )
+        assert result.partial
+        assert "monte_carlo" in result.skipped_tests
+
+    def test_all_missing(self):
+        result = compute_composite_score(None, None, None)
+        assert result.grade == "unknown"
+        assert result.partial
+        assert result.overfitting_pct == 0.0
+
+    def test_wf_zero_is_sharpe_skipped(self):
+        """WF with zero IS Sharpe should be skipped."""
+        result = compute_composite_score(
+            wf_result=_make_wf(is_sharpe=0.0, overfitting_ratio=0.0),
+            perm_result=_make_perm(),
+            mc_result=_make_mc(),
+        )
+        assert "walk_forward" in result.skipped_tests
+
+    def test_wf_no_param_stability(self):
+        """WF present but no param_stability_score → param_stability skipped."""
+        result = compute_composite_score(
+            wf_result=_make_wf(param_stability_score=None),
+            perm_result=_make_perm(),
+            mc_result=_make_mc(),
+        )
+        assert "walk_forward" in result.components
+        assert "param_stability" not in result.components
+
+    def test_to_dict(self):
+        result = compute_composite_score(
+            wf_result=_make_wf(),
+            perm_result=_make_perm(),
+            mc_result=_make_mc(),
+        )
+        d = result.to_dict()
+        assert "overfitting_pct" in d
+        assert "grade" in d
+        assert "components" in d
+        assert "weights_used" in d
+        assert isinstance(d["components"], dict)
+
+    def test_score_clamped_0_to_100(self):
+        """Even with extreme inputs, score stays in 0-100."""
+        result = compute_composite_score(
+            wf_result=_make_wf(overfitting_ratio=-1.0, param_stability_score=5.0),
+            perm_result=_make_perm(p_value=1.0),
+            mc_result=_make_mc(ruin_prob=1.0),
+        )
+        assert 0.0 <= result.overfitting_pct <= 100.0
+
+
+# ─── auto_param_grid ────────────────────────────────────────────────────────
+
+
+class TestAutoParamGrid:
+    def test_ema_crossover(self):
+        grid = auto_param_grid("ema_crossover")
+        assert grid is not None
+        assert "fast_period" in grid
+        assert "slow_period" in grid
+        assert len(grid["fast_period"]) >= 3
+        # Values should be integers for int ranges
+        assert all(isinstance(v, int) for v in grid["fast_period"])
+
+    def test_mean_reversion_float_params(self):
+        grid = auto_param_grid("mean_reversion")
+        assert grid is not None
+        assert "bb_std" in grid
+        # bb_std range is (1.5, 3.0) — should be floats
+        assert all(isinstance(v, float) for v in grid["bb_std"])
+
+    def test_unknown_strategy_returns_none(self):
+        grid = auto_param_grid("nonexistent_strategy")
+        assert grid is None
+
+    def test_ensemble_returns_none(self):
+        """Ensemble has no param_ranges, should return None."""
+        grid = auto_param_grid("ensemble")
+        assert grid is None
+
+    def test_breakout(self):
+        grid = auto_param_grid("breakout")
+        assert grid is not None
+        assert "lookback" in grid

--- a/frontend/app/backtest/page.tsx
+++ b/frontend/app/backtest/page.tsx
@@ -20,7 +20,7 @@ import { StatCard } from "@/components/ui/stat-card";
 import { showSuccess, showError } from "@/lib/toast";
 import { TIMEFRAMES } from "@/components/ui/timeframe-selector";
 import {
-  runBacktest, runOptimize, runWalkForward, runMonteCarlo, runCointegration, runPermutationTest, getCurrentStrategy, getDataStatus, getSymbols,
+  runBacktest, runOptimize, runWalkForward, runMonteCarlo, runCointegration, runPermutationTest, runOverfittingScore, getCurrentStrategy, getDataStatus, getSymbols,
 } from "@/lib/api";
 import {
   AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
@@ -141,6 +141,10 @@ export default function BacktestPage() {
   const [cointRunning, setCointRunning] = useState(false);
   const [permResult, setPermResult] = useState<Record<string, unknown> | null>(null);
   const [permRunning, setPermRunning] = useState(false);
+  // Overfitting score state
+  const [ofResult, setOfResult] = useState<Record<string, unknown> | null>(null);
+  const [ofRunning, setOfRunning] = useState(false);
+  const [ofHistory, setOfHistory] = useState<Record<string, unknown>[]>([]);
 
   const currentParams: ParamDef[] = STRATEGY_PARAMS[strategy] ?? [];
 
@@ -360,6 +364,7 @@ export default function BacktestPage() {
           <TabsTrigger value="walk-forward"><Footprints className="size-3.5 mr-1.5" />Walk Forward</TabsTrigger>
           <TabsTrigger value="monte-carlo"><Dice5 className="size-3.5 mr-1.5" />Monte Carlo</TabsTrigger>
           <TabsTrigger value="significance"><CheckCircle className="size-3.5 mr-1.5" />Significance</TabsTrigger>
+          <TabsTrigger value="overfitting"><AlertTriangle className="size-3.5 mr-1.5" />Overfitting</TabsTrigger>
         </TabsList>
 
         {/* ── Backtest Tab ─────────────────────────────────────── */}
@@ -885,6 +890,201 @@ export default function BacktestPage() {
               )}
             </div>
           </div>
+        </TabsContent>
+
+        {/* ── Overfitting Score Tab ──────────────────────────────── */}
+        <TabsContent value="overfitting" className="space-y-4 mt-0">
+          <div className="border border-border rounded-lg p-4 bg-card space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-medium">Composite Overfitting Score</h3>
+              <Button
+                onClick={async () => {
+                  setOfRunning(true);
+                  setOfResult(null);
+                  try {
+                    const res = await runOverfittingScore({
+                      strategy, symbol, timeframe,
+                      source, count,
+                    });
+                    const data = res.data as Record<string, unknown>;
+                    setOfResult(data);
+                    // Add to comparison history
+                    setOfHistory((prev) => {
+                      const filtered = prev.filter(
+                        (h) => !(h.strategy === data.strategy && h.symbol === data.symbol)
+                      );
+                      return [...filtered, data];
+                    });
+                    showSuccess(`Overfitting score: ${data.overfitting_pct}% (${data.grade})`);
+                  } catch {
+                    showError("Overfitting score computation failed");
+                  } finally {
+                    setOfRunning(false);
+                  }
+                }}
+                disabled={ofRunning}
+                size="sm"
+              >
+                {ofRunning ? <Loader2 className="size-3.5 mr-1.5 animate-spin" /> : <Search className="size-3.5 mr-1.5" />}
+                {ofRunning ? "Computing..." : "Compute Score"}
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Runs walk-forward, permutation test, and monte carlo analysis concurrently. Auto-generates parameter grid from strategy profiles.
+            </p>
+          </div>
+
+          {ofResult && !("error" in ofResult) && (
+            <>
+              {/* Score Display */}
+              <div className={`border rounded-lg p-6 flex flex-col items-center gap-3 ${
+                (ofResult.grade === "healthy") ? "border-green-500/30 bg-green-500/5" :
+                (ofResult.grade === "moderate") ? "border-amber-500/30 bg-amber-500/5" :
+                "border-red-500/30 bg-red-500/5"
+              }`}>
+                <div className="flex items-center gap-3">
+                  {ofResult.grade === "healthy" ? <CheckCircle className="size-8 text-green-400" /> :
+                   ofResult.grade === "moderate" ? <AlertTriangle className="size-8 text-amber-400" /> :
+                   <XCircle className="size-8 text-red-400" />}
+                  <span className={`text-5xl font-bold tabular-nums ${
+                    (ofResult.grade === "healthy") ? "text-green-400" :
+                    (ofResult.grade === "moderate") ? "text-amber-400" :
+                    "text-red-400"
+                  }`}>
+                    {String(ofResult.overfitting_pct)}%
+                  </span>
+                </div>
+                <Badge variant={
+                  ofResult.grade === "healthy" ? "default" :
+                  ofResult.grade === "moderate" ? "secondary" :
+                  "destructive"
+                }>
+                  {String(ofResult.grade).toUpperCase()}
+                </Badge>
+                <p className="text-xs text-muted-foreground">
+                  {String(ofResult.strategy)} on {String(ofResult.symbol)}
+                  {Boolean(ofResult.partial) && (
+                    <span className="ml-2 text-amber-400">
+                      (partial — skipped: {(ofResult.skipped_tests as string[]).join(", ")})
+                    </span>
+                  )}
+                </p>
+                {/* Progress bar */}
+                <div className="w-full max-w-md h-3 bg-muted rounded-full overflow-hidden">
+                  <div
+                    className={`h-full rounded-full transition-all ${
+                      (ofResult.grade === "healthy") ? "bg-green-500" :
+                      (ofResult.grade === "moderate") ? "bg-amber-500" :
+                      "bg-red-500"
+                    }`}
+                    style={{ width: `${Math.min(100, Number(ofResult.overfitting_pct))}%` }}
+                  />
+                </div>
+              </div>
+
+              {/* Component Breakdown */}
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                {Object.entries(ofResult.components as Record<string, number>).map(([key, value]) => (
+                  <StatCard
+                    key={key}
+                    icon={
+                      key === "walk_forward" ? Footprints :
+                      key === "permutation" ? Dice5 :
+                      key === "param_stability" ? Target :
+                      BarChart3
+                    }
+                    label={key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
+                    value={`${value}%`}
+                    variant={value < 30 ? "success" : value < 60 ? "warning" : "danger"}
+                  />
+                ))}
+              </div>
+
+              {/* Walk-Forward Detail */}
+              {ofResult.walk_forward && (
+                <div className="border border-border rounded-lg p-4 bg-card space-y-2">
+                  <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Walk-Forward Detail</h4>
+                  <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
+                    <div><span className="text-muted-foreground">IS Sharpe:</span> {String((ofResult.walk_forward as Record<string, unknown>).is_sharpe)}</div>
+                    <div><span className="text-muted-foreground">OOS Sharpe:</span> {String((ofResult.walk_forward as Record<string, unknown>).oos_sharpe)}</div>
+                    <div><span className="text-muted-foreground">Ratio:</span> {String((ofResult.walk_forward as Record<string, unknown>).overfitting_ratio)}</div>
+                    <div><span className="text-muted-foreground">Param CV:</span> {String((ofResult.walk_forward as Record<string, unknown>).param_stability_score ?? "N/A")}</div>
+                  </div>
+                </div>
+              )}
+
+              {/* Permutation Detail */}
+              {ofResult.permutation && (
+                <div className="border border-border rounded-lg p-4 bg-card space-y-2">
+                  <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Permutation Test Detail</h4>
+                  <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
+                    <div><span className="text-muted-foreground">Real Sharpe:</span> {String((ofResult.permutation as Record<string, unknown>).real_sharpe)}</div>
+                    <div><span className="text-muted-foreground">p-value:</span> {String((ofResult.permutation as Record<string, unknown>).p_value)}</div>
+                    <div><span className="text-muted-foreground">Significant:</span> {(ofResult.permutation as Record<string, unknown>).is_significant ? "Yes" : "No"}</div>
+                    <div><span className="text-muted-foreground">Shuffled Mean:</span> {String((ofResult.permutation as Record<string, unknown>).shuffled_mean)}</div>
+                  </div>
+                </div>
+              )}
+
+              {/* Monte Carlo Detail */}
+              {ofResult.monte_carlo && (
+                <div className="border border-border rounded-lg p-4 bg-card space-y-2">
+                  <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Monte Carlo Detail</h4>
+                  <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
+                    <div><span className="text-muted-foreground">Ruin Prob:</span> {String((ofResult.monte_carlo as Record<string, unknown>).probability_of_ruin)}</div>
+                    <div><span className="text-muted-foreground">Profit Prob:</span> {String((ofResult.monte_carlo as Record<string, unknown>).probability_of_profit)}</div>
+                    <div><span className="text-muted-foreground">p95 DD:</span> {String((ofResult.monte_carlo as Record<string, unknown>).p95_max_drawdown)}</div>
+                    <div><span className="text-muted-foreground">Median Balance:</span> {String((ofResult.monte_carlo as Record<string, unknown>).median_final_balance)}</div>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+
+          {ofResult && "error" in ofResult && (
+            <div className="border border-red-500/30 bg-red-500/5 rounded-lg p-4 text-red-400 text-sm">
+              {String(ofResult.error)}
+            </div>
+          )}
+
+          {/* Comparison History */}
+          {ofHistory.length > 1 && (
+            <div className="border border-border rounded-lg p-4 bg-card space-y-3">
+              <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Strategy Comparison</h4>
+              <div className="space-y-2">
+                {ofHistory.map((h, i) => {
+                  const pct = Number(h.overfitting_pct);
+                  const grade = String(h.grade);
+                  return (
+                    <div key={i} className="flex items-center gap-3">
+                      <span className="text-sm w-32 truncate">{String(h.strategy)}</span>
+                      <div className="flex-1 h-4 bg-muted rounded-full overflow-hidden">
+                        <div
+                          className={`h-full rounded-full transition-all ${
+                            grade === "healthy" ? "bg-green-500" :
+                            grade === "moderate" ? "bg-amber-500" :
+                            "bg-red-500"
+                          }`}
+                          style={{ width: `${Math.min(100, pct)}%` }}
+                        />
+                      </div>
+                      <span className={`text-sm font-mono w-14 text-right ${
+                        grade === "healthy" ? "text-green-400" :
+                        grade === "moderate" ? "text-amber-400" :
+                        "text-red-400"
+                      }`}>{pct}%</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {!ofResult && !ofRunning && (
+            <p className="text-xs text-muted-foreground text-center py-4">
+              Combines walk-forward ratio (40%), permutation p-value (25%), param stability (20%), and monte carlo ruin probability (15%) into a single overfitting score
+            </p>
+          )}
         </TabsContent>
       </Tabs>
     </div>

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -27,7 +27,7 @@ import {
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { ConnectionStatus } from "@/components/ui/connection-status";
-import { NotificationCenter } from "@/components/ui/notification-center";
+
 
 interface NavItem { href: string; label: string; icon: typeof LayoutDashboard; }
 interface NavGroup { label: string; items: NavItem[]; }
@@ -162,7 +162,6 @@ function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
       <div className="p-4 space-y-1">
         <ConnectionStatus />
         <div className="flex items-center gap-1 px-1">
-          <NotificationCenter />
           <ThemeToggle />
         </div>
         <LogoutButton />

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -189,6 +189,11 @@ export const runPermutationTest = (params: {
   include_costs?: boolean;
 }) => api.post("/api/backtest/permutation-test", params, { timeout: 300000 });
 
+export const runOverfittingScore = (params: {
+  strategy: string; symbol?: string; timeframe?: string;
+  source?: string; count?: number;
+}) => api.post("/api/backtest/overfitting-score", params, { timeout: 300000 });
+
 // Macro Data
 export const getMacroLatest = () => api.get("/api/macro/latest");
 export const getMacroCorrelations = (days?: number) =>


### PR DESCRIPTION
## Summary
- **Composite Overfitting Score** (0-100%): combines walk-forward ratio (40%), permutation p-value (25%), param stability CV (20%), and monte carlo ruin probability (15%) into a single metric with grade (healthy/moderate/overfit)
- **MCP Tool** `compute_overfitting_score`: AI autonomous agents (Reflector, Risk Analyst) can now check strategy overfitting before making decisions. Orchestrator reduces lot size 50% when overfitting >60%
- **Frontend "Overfitting" tab**: score gauge, grade badge, component breakdown, strategy comparison chart
- **Sidebar cleanup**: removed notification bell button from footer

## New Files
| File | Purpose |
|------|---------|
| `backend/app/backtest/overfitting.py` | Core composite score logic + auto param_grid |
| `backend/mcp_server/tools/overfitting.py` | MCP tool (HTTP wrapper) |
| `backend/tests/unit/test_overfitting_score.py` | 26 unit tests |

## Modified Files
| File | Change |
|------|--------|
| `backend/app/api/routes/backtest.py` | `POST /api/backtest/overfitting-score` endpoint |
| `backend/mcp_server/server.py` | Register MCP tool |
| `backend/mcp_server/agents/reflector.py` | Add tool + prompt for overfitting check |
| `backend/mcp_server/agents/risk_analyst.py` | Add tool + prompt |
| `backend/mcp_server/agents/orchestrator.py` | Overfitting-aware lot sizing rules |
| `frontend/app/backtest/page.tsx` | New "Overfitting" tab |
| `frontend/lib/api.ts` | `runOverfittingScore()` API function |
| `frontend/components/layout/Sidebar.tsx` | Remove notification bell |

## Test plan
- [x] 26 unit tests pass (`pytest tests/unit/test_overfitting_score.py`)
- [x] TypeScript type check clean (`tsc --noEmit`)
- [x] Frontend build succeeds (`npm run build`)
- [ ] Manual: backtest page → Overfitting tab → compute score for ema_crossover
- [ ] Manual: verify Reflector agent calls `compute_overfitting_score` in multi-agent mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)