### PR TITLE
feat: composite overfitting score + AI auto-strategy switch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,9 @@ Frontend (Next.js 16) → Backend (FastAPI) → MT5 Bridge (Windows VPS)
   - `logging_config.py` — structured JSON logging
 - `backend/mcp_server/` — MCP Agent system (Claude Code SDK)
   - `agents/` — orchestrator, technical/fundamental/risk analysts, reflector, prompt_registry
-  - `tools/` — 13 tool modules (broker, market_data, indicators, risk, portfolio, sentiment, history, journal, learning, session, strategy_gen, memory, overfitting)
+  - `tools/` — 14 tool modules (broker, market_data, indicators, risk, portfolio, sentiment, history, journal, learning, session, strategy_gen, memory, overfitting, strategy_switch)
   - `guardrails.py` — non-bypassable trading limits at broker tool level
+  - `strategy_switch_guard.py` — AI auto-strategy-switch safety (cooldown 1h, max 3/day, feature flag)
   - `sdk_client.py` — Claude Code SDK client
   - `server.py` — MCP server entry
   - `agent_config.py` — agent entry point

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Frontend (Next.js 16) → Backend (FastAPI) → MT5 Bridge (Windows VPS)
   - `lib/websocket.ts` — WS client with token auth
 - `mt5_bridge/` — FastAPI on Windows VPS (MetaTrader5 SDK)
 - `scripts/backup_db.sh` — daily pg_dump
-- `backend/tests/` — 429 tests across 26 test files (unit + integration)
+- `backend/tests/` — 444 tests across 27 test files (unit + integration)
 - `Dockerfile.trading-agent` — Python 3.11-slim agent image
 
 ## Tech Stack
@@ -176,7 +176,7 @@ railway vars set -s backend "KEY=value"  # set env var
 - **DB session**: Shared session can get dirty — always `rollback()` before new operations in long-lived services
 - **SYMBOL_PROFILES**: Per-symbol config in config.py (timeframe, pip_value, SL/TP mults, ML defaults)
 - **Constants**: All magic numbers in `constants.py` — never hardcode
-- **Tests**: 403 tests across 25 files. SQLite in-memory for DB, fakeredis, mock MT5 connector. Auth disabled via `os.environ["AUTH_PASSWORD_HASH"] = ""` in conftest.py. SDK mocks use `type` attribute instead of `isinstance`.
+- **Tests**: 444 tests across 27 files. SQLite in-memory for DB, fakeredis, mock MT5 connector. Auth disabled via `os.environ["AUTH_PASSWORD_HASH"] = ""` in conftest.py. SDK mocks use `type` attribute instead of `isinstance`.
 - **Runner**: `RunnerManager` init in `main.py` lifespan. Uses `ProcessRunnerBackend` by default (Railway-compatible). Heartbeat monitor runs as APScheduler job. Job queue uses dual Redis+DB storage. Runner logs streamed via Redis pub/sub to WebSocket.
 - **Coverage**: CI threshold 25% (overall ~29%, critical paths ~89%)
 - **Telegram**: Notifications for trade signals, AI analysis, system alerts. Thai language alerts.

--- a/backend/app/api/routes/bot.py
+++ b/backend/app/api/routes/bot.py
@@ -3,19 +3,16 @@ Bot control API routes (multi-symbol).
 """
 
 from datetime import datetime, timedelta
-
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, Field
-
 from loguru import logger
-
-from app.auth import require_auth
-from app.config import settings
+from pydantic import BaseModel, Field
 from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth import require_auth
+from app.config import settings
 from app.db.models import BotEvent
 from app.db.session import get_db
 
@@ -62,6 +59,13 @@ class StrategyUpdate(BaseModel):
     symbol: str | None = None
 
 
+class StrategyApply(BaseModel):
+    name: str
+    params: dict | None = None
+    symbol: str | None = None
+    reasoning: str = ""
+
+
 class SettingsUpdate(BaseModel):
     symbol: str | None = None
     use_ai_filter: bool | None = None
@@ -74,6 +78,7 @@ class SettingsUpdate(BaseModel):
     max_lot: float | None = Field(None, ge=0.01, le=1.0)
     fixed_lot: float | None = Field(None, ge=0.01, le=1.0)
     lot_mode: Literal["fixed", "auto"] | None = None
+    enable_auto_strategy_switch: bool | None = None
 
 
 @router.post("/start", dependencies=[Depends(require_auth)])
@@ -204,6 +209,31 @@ async def update_strategy(data: StrategyUpdate):
         raise HTTPException(status_code=400, detail=str(e))
 
 
+@router.put("/strategy-apply", dependencies=[Depends(require_auth)])
+async def apply_strategy_in_ai_mode(data: StrategyApply):
+    """Apply a strategy to the engine without changing trading mode.
+
+    Used by AI auto-strategy-switch to set a real strategy while staying in ai_autonomous mode.
+    """
+    engine = _get_engine(data.symbol)
+    try:
+        await engine.update_strategy(data.name, data.params)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    from app.db.models import BotEventType
+
+    try:
+        await engine._log_event(
+            BotEventType.STRATEGY_CHANGED,
+            f"[Auto-Switch] → {data.name} | {data.reasoning[:200]}",
+        )
+    except Exception as e:
+        logger.debug(f"Failed to log strategy switch event: {e}")
+
+    return {"status": "applied", "strategy": data.name, "symbol": engine.symbol}
+
+
 @router.put("/settings", dependencies=[Depends(require_auth)])
 async def update_settings(data: SettingsUpdate):
     # Resolve fixed_lot from lot_mode: "auto" → None, "fixed" → use fixed_lot value
@@ -241,6 +271,19 @@ async def update_settings(data: SettingsUpdate):
                 max_lot=data.max_lot,
                 fixed_lot=resolved_fixed_lot,
             )
+
+    # Persist auto-strategy-switch flag to Redis (global, not per-engine)
+    if data.enable_auto_strategy_switch is not None:
+        try:
+            engine = _get_engine()
+            await engine.redis.set(
+                "enable_auto_strategy_switch",
+                "1" if data.enable_auto_strategy_switch else "0",
+            )
+            settings.enable_auto_strategy_switch = data.enable_auto_strategy_switch
+        except Exception as e:
+            logger.debug(f"Redis enable_auto_strategy_switch write failed: {e}")
+
     return {"status": "updated"}
 
 

--- a/backend/app/bot/manager.py
+++ b/backend/app/bot/manager.py
@@ -107,6 +107,7 @@ class BotManager:
             "symbols": symbols_status,
             "active_count": running,
             "total_count": len(self.engines),
+            "enable_auto_strategy_switch": settings.enable_auto_strategy_switch,
         }
 
     async def get_active_positions(self) -> dict[str, list[dict]]:

--- a/backend/app/bot/scheduler.py
+++ b/backend/app/bot/scheduler.py
@@ -449,18 +449,30 @@ class BotScheduler:
                     await engine._notify(engine.notifier.send_optimization_report(
                         result.assessment, result.confidence,
                     ))
-                    # Auto-apply if feature flag ON and backtest confirms improvement
-                    if (
-                        result.backtest_validation
-                        and result.backtest_validation.get("suggested_better")
-                        and settings.enable_auto_strategy_switch
-                    ):
-                        strategy_name = engine.strategy.name if engine.strategy else "ema_crossover"
-                        await engine.update_strategy(strategy_name, result.suggested_params)
-                        logger.info(
-                            f"[Optimizer Auto-Apply] [{engine.symbol}] "
-                            f"params={result.suggested_params} confidence={result.confidence}"
-                        )
+                    # Auto-apply if feature flag ON and backtest confirms improvement.
+                    # Read from Redis (not in-memory settings) so the flag survives restarts.
+                    if result.backtest_validation and result.backtest_validation.get("suggested_better"):
+                        flag_raw = await engine.redis.get("enable_auto_strategy_switch")
+                        flag_on = (flag_raw == b"1" or flag_raw == "1") if flag_raw else False
+                        if flag_on:
+                            from mcp_server.strategy_switch_guard import StrategySwitchGuard
+                            guard = StrategySwitchGuard(engine.redis)
+                            strategy_name = engine.strategy.name if engine.strategy else "ema_crossover"
+                            validation = await guard.validate_switch(engine.symbol, strategy_name)
+                            if validation.allowed:
+                                await engine.update_strategy(strategy_name, result.suggested_params)
+                                await guard.record_switch(
+                                    engine.symbol, strategy_name,
+                                    f"Weekly optimizer: confidence={result.confidence}",
+                                )
+                                logger.info(
+                                    f"[Optimizer Auto-Apply] [{engine.symbol}] "
+                                    f"params={result.suggested_params} confidence={result.confidence}"
+                                )
+                            else:
+                                logger.info(
+                                    f"[Optimizer Auto-Apply] [{engine.symbol}] blocked: {validation.reason}"
+                                )
             except Exception as e:
                 logger.error(f"Weekly optimization error [{engine.symbol}]: {e}")
 

--- a/backend/app/bot/scheduler.py
+++ b/backend/app/bot/scheduler.py
@@ -4,7 +4,7 @@ Scheduler — APScheduler jobs for bot operations (multi-symbol).
 
 import asyncio
 from collections import defaultdict
-from datetime import datetime
+from datetime import UTC, datetime
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from loguru import logger
@@ -449,6 +449,18 @@ class BotScheduler:
                     await engine._notify(engine.notifier.send_optimization_report(
                         result.assessment, result.confidence,
                     ))
+                    # Auto-apply if feature flag ON and backtest confirms improvement
+                    if (
+                        result.backtest_validation
+                        and result.backtest_validation.get("suggested_better")
+                        and settings.enable_auto_strategy_switch
+                    ):
+                        strategy_name = engine.strategy.name if engine.strategy else "ema_crossover"
+                        await engine.update_strategy(strategy_name, result.suggested_params)
+                        logger.info(
+                            f"[Optimizer Auto-Apply] [{engine.symbol}] "
+                            f"params={result.suggested_params} confidence={result.confidence}"
+                        )
             except Exception as e:
                 logger.error(f"Weekly optimization error [{engine.symbol}]: {e}")
 
@@ -483,9 +495,11 @@ class BotScheduler:
         """Daily trading summary at market close — sends Telegram report."""
         logger.info("Daily summary triggered")
         try:
-            from sqlalchemy import select, and_, func
+            from datetime import datetime
+
+            from sqlalchemy import and_, select
+
             from app.db.models import Trade
-            from datetime import datetime, timezone, timedelta
 
             symbol_stats = []
             total_pnl = 0.0
@@ -494,7 +508,7 @@ class BotScheduler:
 
             for symbol, engine in self._engines.items():
                 # Get today's closed trades
-                today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=None)
+                today_start = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=None)
                 stmt = select(Trade).where(and_(
                     Trade.symbol == symbol,
                     Trade.close_time >= today_start,
@@ -584,7 +598,6 @@ class BotScheduler:
             import joblib
             from sqlalchemy import select, update
 
-            from app.config import settings
             from app.data.collector import DataCollector
             from app.db.models import MLModelLog
             from app.db.session import async_session

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,6 +1,4 @@
 from pydantic_settings import BaseSettings
-from pydantic import Field
-
 
 # Per-symbol trading profiles
 SYMBOL_PROFILES: dict[str, dict] = {
@@ -181,6 +179,7 @@ class Settings(BaseSettings):
     enable_scale_in: bool = False     # enable momentum add-on positions
     max_scale_in_count: int = 1       # max add-on entries per position
     enable_partial_tp: bool = False   # enable close-and-reopen partial TP
+    enable_auto_strategy_switch: bool = False  # AI agent can switch strategies based on regime
 
     # Portfolio risk
     max_portfolio_leverage: float = 3.0  # block trades when total leverage exceeds this

--- a/backend/mcp_server/agents/reflector.py
+++ b/backend/mcp_server/agents/reflector.py
@@ -8,7 +8,7 @@ Uses: learning + session + strategy_gen tools.
 Model: Haiku (fast review, cost-efficient).
 """
 
-from mcp_server.agents.base import run_agent_loop, MODEL_SPECIALIST
+from mcp_server.agents.base import MODEL_SPECIALIST, run_agent_loop
 
 SYSTEM_PROMPT = """You are a Trade Reflector for a multi-symbol trading system. Your job is to review recent trading performance and extract actionable learnings.
 
@@ -38,6 +38,14 @@ After your analysis:
 - Use `save_learning` for any new cross-session insights (7-day Redis cache)
 - Use `recommend_strategy` to suggest the best strategy for the regime
 
+## Auto Strategy Switching
+After recommending a strategy via `recommend_strategy`, if it differs from the current:
+- Use `apply_strategy` to switch. Include reasoning with evidence from regime + performance.
+- The tool enforces guards (cooldown 1h, max 3/day, feature flag).
+- If the tool returns {"applied": false}, respect the rejection and mention it in your report.
+- Only switch when regime has CLEARLY changed AND current strategy performance is degrading.
+- Use `get_switch_status` to check current switch state before attempting.
+
 ## Persistent Memory (Long-term Learning)
 - Use `get_memories` to recall past insights for this symbol (mid-term 30d + long-term permanent)
 - If a stored memory's prediction matched recent outcomes → `validate_memory(id, hit=true)`
@@ -60,6 +68,8 @@ TOOL_NAMES = [
     "get_strategy_profiles",
     "recommend_strategy",
     "compute_overfitting_score",
+    "apply_strategy",
+    "get_switch_status",
     "get_memories",
     "save_memory",
     "validate_memory",

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -26,6 +26,7 @@ from mcp_server.tools import (
     sentiment,
     session,
     strategy_gen,
+    strategy_switch,
 )
 
 
@@ -256,6 +257,24 @@ def create_server() -> FastMCP:
         """Compute composite overfitting score (0-100%) for a strategy.
         Combines walk-forward ratio, permutation test, param stability, and monte carlo ruin probability."""
         return await overfitting.compute_overfitting_score(strategy, symbol, timeframe, source, count)
+
+    # ─── Strategy Switch Tools ───────────────────────────────────────
+
+    @mcp.tool()
+    async def apply_strategy(
+        symbol: str,
+        strategy_name: str,
+        params: str | None = None,
+        reasoning: str = "",
+    ) -> dict:
+        """Apply a strategy to the trading engine based on market regime analysis.
+        Only works when enable_auto_strategy_switch is ON. Cooldown: 1h, max 3/day."""
+        return await strategy_switch.apply_strategy(symbol, strategy_name, params, reasoning)
+
+    @mcp.tool()
+    async def get_switch_status(symbol: str = "GOLD") -> dict:
+        """Get auto-strategy-switch status: enabled, current strategy, cooldown, daily count."""
+        return await strategy_switch.get_switch_status(symbol)
 
     return mcp
 

--- a/backend/mcp_server/strategy_switch_guard.py
+++ b/backend/mcp_server/strategy_switch_guard.py
@@ -1,0 +1,156 @@
+"""
+Strategy Switch Guard — enforces safety limits on AI auto-strategy switching.
+
+Redis-backed: cooldown, daily rate limit, feature flag check.
+Pattern follows guardrails.py + param_gate.py.
+"""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import redis.asyncio as redis_lib
+from loguru import logger
+
+_KEY_PREFIX = "strategy_switch"
+
+COOLDOWN_SECONDS = 3600  # 1 hour between switches
+MAX_DAILY_SWITCHES = 3
+
+
+def _decode(val: bytes | str | None) -> str | None:
+    """Decode a Redis value that may be bytes, str, or None."""
+    if val is None:
+        return None
+    return val.decode() if isinstance(val, bytes) else str(val)
+
+
+@dataclass
+class SwitchResult:
+    allowed: bool
+    reason: str = ""
+
+
+class StrategySwitchGuard:
+    """Enforces safety guardrails for AI auto-strategy switching."""
+
+    def __init__(self, redis: redis_lib.Redis):
+        self.redis = redis
+
+    async def is_enabled(self) -> bool:
+        """Check if auto-strategy-switch feature flag is ON."""
+        val = await self.redis.get("enable_auto_strategy_switch")
+        return _decode(val) == "1"
+
+    async def validate_switch(
+        self,
+        symbol: str,
+        to_strategy: str,
+    ) -> SwitchResult:
+        """Validate whether a strategy switch is allowed.
+
+        Checks: feature flag, cooldown, daily limit, same-strategy guard.
+        """
+        # Fetch all guard keys in one pipeline round-trip
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
+        pipe = self.redis.pipeline()
+        pipe.get("enable_auto_strategy_switch")
+        pipe.get(f"{_KEY_PREFIX}:current:{symbol}")
+        pipe.get(f"{_KEY_PREFIX}:last:{symbol}")
+        pipe.get(f"{_KEY_PREFIX}:count:{today}")
+        enabled_raw, current_raw, last_raw, count_raw = await pipe.execute()
+
+        # 1. Feature flag
+        if _decode(enabled_raw) != "1":
+            return SwitchResult(False, "Auto strategy switch is disabled (feature flag OFF)")
+
+        # 2. Market open check
+        try:
+            from app.bot.scheduler import is_market_open
+
+            if not is_market_open(symbol):
+                return SwitchResult(False, f"Market closed for {symbol}")
+        except ImportError:
+            pass  # Skip in tests — scheduler imports MT5/APScheduler deps
+
+        # 3. Same-strategy guard
+        current_name = _decode(current_raw)
+        if current_name and current_name == to_strategy:
+            return SwitchResult(False, f"Already using {to_strategy} for {symbol}")
+
+        # 4. Cooldown check (1 hour)
+        last_str = _decode(last_raw)
+        if last_str:
+            elapsed = datetime.now(UTC).timestamp() - float(last_str)
+            if elapsed < COOLDOWN_SECONDS:
+                remaining = int(COOLDOWN_SECONDS - elapsed)
+                return SwitchResult(
+                    False,
+                    f"Cooldown active: {remaining}s remaining (min {COOLDOWN_SECONDS}s between switches)",
+                )
+
+        # 5. Daily limit
+        daily_count = int(_decode(count_raw)) if count_raw else 0
+        if daily_count >= MAX_DAILY_SWITCHES:
+            return SwitchResult(
+                False,
+                f"Daily limit reached: {daily_count}/{MAX_DAILY_SWITCHES} switches today",
+            )
+
+        return SwitchResult(True)
+
+    async def record_switch(
+        self,
+        symbol: str,
+        strategy_name: str,
+        reasoning: str = "",
+    ) -> None:
+        """Record a successful strategy switch in Redis."""
+        now = datetime.now(UTC)
+        today = now.strftime("%Y-%m-%d")
+        count_key = f"{_KEY_PREFIX}:count:{today}"
+
+        pipe = self.redis.pipeline()
+        pipe.set(f"{_KEY_PREFIX}:last:{symbol}", str(now.timestamp()))
+        pipe.set(f"{_KEY_PREFIX}:current:{symbol}", strategy_name)
+        pipe.incr(count_key)
+        pipe.expire(count_key, 86400)  # TTL 24h
+        await pipe.execute()
+
+        logger.info(
+            f"Strategy switch recorded [{symbol}]: → {strategy_name} "
+            f"| reason: {reasoning[:100]}"
+        )
+
+    async def get_status(self, symbol: str) -> dict:
+        """Get current switch guard status for a symbol."""
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
+        pipe = self.redis.pipeline()
+        pipe.get("enable_auto_strategy_switch")
+        pipe.get(f"{_KEY_PREFIX}:current:{symbol}")
+        pipe.get(f"{_KEY_PREFIX}:last:{symbol}")
+        pipe.get(f"{_KEY_PREFIX}:count:{today}")
+        enabled_raw, current_raw, last_raw, count_raw = await pipe.execute()
+
+        enabled = _decode(enabled_raw) == "1"
+        current_strategy = _decode(current_raw)
+
+        last_switch = None
+        cooldown_remaining = 0
+        last_str = _decode(last_raw)
+        if last_str:
+            last_time = float(last_str)
+            last_switch = datetime.fromtimestamp(last_time, tz=UTC).isoformat()
+            elapsed = datetime.now(UTC).timestamp() - last_time
+            cooldown_remaining = max(0, int(COOLDOWN_SECONDS - elapsed))
+
+        daily_count = int(_decode(count_raw)) if count_raw else 0
+
+        return {
+            "enabled": enabled,
+            "current_strategy": current_strategy,
+            "last_switch": last_switch,
+            "cooldown_remaining_s": cooldown_remaining,
+            "daily_switches": daily_count,
+            "max_daily": MAX_DAILY_SWITCHES,
+            "cooldown_s": COOLDOWN_SECONDS,
+        }

--- a/backend/mcp_server/tools/__init__.py
+++ b/backend/mcp_server/tools/__init__.py
@@ -13,5 +13,7 @@ def init_mcp_tools(redis_client) -> None:
     """Initialize all MCP tools that require Redis. Idempotent — safe to call once at startup."""
     from mcp_server.tools.broker import init_broker
     from mcp_server.tools.session import init_session
+    from mcp_server.tools.strategy_switch import init_strategy_switch
     init_broker(redis_client)
     init_session(redis_client)
+    init_strategy_switch(redis_client)

--- a/backend/mcp_server/tools/strategy_switch.py
+++ b/backend/mcp_server/tools/strategy_switch.py
@@ -1,0 +1,119 @@
+"""MCP tool for AI auto-strategy switching — wraps /api/bot/strategy-apply with guards."""
+
+import httpx
+import redis.asyncio as redis_lib
+from loguru import logger
+
+from mcp_server.strategy_switch_guard import StrategySwitchGuard
+from mcp_server.tools import backend_url as _backend_url
+
+_guard: StrategySwitchGuard | None = None
+
+
+def init_strategy_switch(redis_client: redis_lib.Redis) -> None:
+    """Initialize the strategy switch guard with Redis."""
+    global _guard
+    _guard = StrategySwitchGuard(redis_client)
+
+
+def _require_guard() -> StrategySwitchGuard:
+    if _guard is None:
+        raise RuntimeError("Strategy switch guard not initialized — call init_strategy_switch() first")
+    return _guard
+
+
+async def apply_strategy(
+    symbol: str,
+    strategy_name: str,
+    params: str | None = None,
+    reasoning: str = "",
+) -> dict:
+    """Apply a strategy to the trading engine based on market regime analysis.
+
+    Only works when enable_auto_strategy_switch is ON.
+    Subject to cooldown (1h) and daily limits (3/day).
+    Respects rollout mode: shadow/paper = log only.
+
+    Args:
+        symbol: Trading symbol (e.g. "GOLD", "BTCUSD")
+        strategy_name: Strategy to switch to (e.g. "ema_crossover", "breakout")
+        params: Optional JSON string of strategy parameters
+        reasoning: Why the switch is needed (evidence from regime detection)
+
+    Returns:
+        Dict with applied (bool), strategy, symbol, and reason if rejected.
+    """
+    guard = _require_guard()
+
+    # Validate switch against guards
+    result = await guard.validate_switch(symbol, strategy_name)
+    if not result.allowed:
+        logger.info(f"Strategy switch blocked [{symbol}] → {strategy_name}: {result.reason}")
+        return {
+            "applied": False,
+            "strategy": strategy_name,
+            "symbol": symbol,
+            "reason": result.reason,
+        }
+
+    # Parse params if provided as JSON string
+    import json
+
+    parsed_params = None
+    if params:
+        try:
+            parsed_params = json.loads(params)
+        except json.JSONDecodeError as e:
+            logger.warning(f"apply_strategy: invalid params JSON for {symbol}: {e}")
+            parsed_params = None
+
+    # Call backend API to apply strategy
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.put(
+                f"{_backend_url()}/api/bot/strategy-apply",
+                json={
+                    "name": strategy_name,
+                    "params": parsed_params,
+                    "symbol": symbol,
+                    "reasoning": reasoning[:500],
+                },
+            )
+            if resp.status_code != 200:
+                return {
+                    "applied": False,
+                    "strategy": strategy_name,
+                    "symbol": symbol,
+                    "reason": f"Backend returned {resp.status_code}: {resp.text[:200]}",
+                }
+    except Exception as e:
+        return {
+            "applied": False,
+            "strategy": strategy_name,
+            "symbol": symbol,
+            "reason": f"Failed to call backend: {e}",
+        }
+
+    # Record successful switch
+    await guard.record_switch(symbol, strategy_name, reasoning)
+
+    logger.info(f"Strategy switched [{symbol}] → {strategy_name} | {reasoning[:100]}")
+    return {
+        "applied": True,
+        "strategy": strategy_name,
+        "symbol": symbol,
+        "reasoning": reasoning[:200],
+    }
+
+
+async def get_switch_status(symbol: str = "GOLD") -> dict:
+    """Get current auto-strategy-switch status for a symbol.
+
+    Args:
+        symbol: Trading symbol
+
+    Returns:
+        Dict with enabled, current_strategy, cooldown info, daily count.
+    """
+    guard = _require_guard()
+    return await guard.get_status(symbol)

--- a/backend/mcp_server/tools/strategy_switch.py
+++ b/backend/mcp_server/tools/strategy_switch.py
@@ -45,6 +45,19 @@ async def apply_strategy(
     """
     guard = _require_guard()
 
+    # Rollout mode guard: shadow/paper = log only, no real switch
+    from app.config import settings as _settings
+    if _settings.rollout_mode in ("shadow", "paper"):
+        logger.info(
+            f"[{_settings.rollout_mode}] Strategy switch logged only: {symbol} → {strategy_name} | {reasoning[:100]}"
+        )
+        return {
+            "applied": False,
+            "strategy": strategy_name,
+            "symbol": symbol,
+            "reason": f"Rollout mode '{_settings.rollout_mode}' — logged only, no real switch",
+        }
+
     # Validate switch against guards
     result = await guard.validate_switch(symbol, strategy_name)
     if not result.allowed:
@@ -60,12 +73,13 @@ async def apply_strategy(
     import json
 
     parsed_params = None
+    params_warning = None
     if params:
         try:
             parsed_params = json.loads(params)
         except json.JSONDecodeError as e:
             logger.warning(f"apply_strategy: invalid params JSON for {symbol}: {e}")
-            parsed_params = None
+            params_warning = f"params JSON invalid ({e}), applied with default params"
 
     # Call backend API to apply strategy
     try:
@@ -98,12 +112,15 @@ async def apply_strategy(
     await guard.record_switch(symbol, strategy_name, reasoning)
 
     logger.info(f"Strategy switched [{symbol}] → {strategy_name} | {reasoning[:100]}")
-    return {
+    response: dict = {
         "applied": True,
         "strategy": strategy_name,
         "symbol": symbol,
         "reasoning": reasoning[:200],
     }
+    if params_warning:
+        response["warning"] = params_warning
+    return response
 
 
 async def get_switch_status(symbol: str = "GOLD") -> dict:

--- a/backend/tests/unit/test_strategy_switch_guard.py
+++ b/backend/tests/unit/test_strategy_switch_guard.py
@@ -1,0 +1,166 @@
+"""
+Unit tests for strategy switch guard — cooldown, rate limit, feature flag.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+
+from mcp_server.strategy_switch_guard import (
+    COOLDOWN_SECONDS,
+    MAX_DAILY_SWITCHES,
+    StrategySwitchGuard,
+)
+
+
+@pytest_asyncio.fixture
+async def guard(redis_client):
+    return StrategySwitchGuard(redis_client)
+
+
+# ─── Feature flag ───────────────────────────────────────────────────────────
+
+
+class TestFeatureFlag:
+    @pytest.mark.asyncio
+    async def test_disabled_by_default(self, guard):
+        result = await guard.is_enabled()
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_enable_via_redis(self, guard):
+        await guard.redis.set("enable_auto_strategy_switch", "1")
+        assert await guard.is_enabled() is True
+
+    @pytest.mark.asyncio
+    async def test_disable_via_redis(self, guard):
+        await guard.redis.set("enable_auto_strategy_switch", "0")
+        assert await guard.is_enabled() is False
+
+
+# ─── Validate switch ────────────────────────────────────────────────────────
+# Note: is_market_open check is skipped in tests because app.bot.scheduler
+# cannot be imported without full app context. The guard catches ImportError.
+
+
+class TestValidateSwitch:
+    @pytest.mark.asyncio
+    async def test_rejects_when_disabled(self, guard):
+        result = await guard.validate_switch("GOLD", "breakout")
+        assert not result.allowed
+        assert "feature flag OFF" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_allows_when_enabled(self, guard):
+        await guard.redis.set("enable_auto_strategy_switch", "1")
+        result = await guard.validate_switch("GOLD", "breakout")
+        assert result.allowed
+
+    @pytest.mark.asyncio
+    async def test_rejects_same_strategy(self, guard):
+        await guard.redis.set("enable_auto_strategy_switch", "1")
+        await guard.redis.set("strategy_switch:current:GOLD", "breakout")
+        result = await guard.validate_switch("GOLD", "breakout")
+        assert not result.allowed
+        assert "Already using" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_allows_different_strategy(self, guard):
+        await guard.redis.set("enable_auto_strategy_switch", "1")
+        await guard.redis.set("strategy_switch:current:GOLD", "ema_crossover")
+        result = await guard.validate_switch("GOLD", "breakout")
+        assert result.allowed
+
+    @pytest.mark.asyncio
+    async def test_rejects_during_cooldown(self, guard):
+        await guard.redis.set("enable_auto_strategy_switch", "1")
+        now = datetime.now(UTC).timestamp()
+        await guard.redis.set("strategy_switch:last:GOLD", str(now - 10))
+        result = await guard.validate_switch("GOLD", "breakout")
+        assert not result.allowed
+        assert "Cooldown" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_allows_after_cooldown(self, guard):
+        await guard.redis.set("enable_auto_strategy_switch", "1")
+        now = datetime.now(UTC).timestamp()
+        await guard.redis.set("strategy_switch:last:GOLD", str(now - 7200))
+        result = await guard.validate_switch("GOLD", "breakout")
+        assert result.allowed
+
+    @pytest.mark.asyncio
+    async def test_rejects_at_daily_limit(self, guard):
+        await guard.redis.set("enable_auto_strategy_switch", "1")
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
+        await guard.redis.set(f"strategy_switch:count:{today}", str(MAX_DAILY_SWITCHES))
+        result = await guard.validate_switch("GOLD", "breakout")
+        assert not result.allowed
+        assert "Daily limit" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_allows_under_daily_limit(self, guard):
+        await guard.redis.set("enable_auto_strategy_switch", "1")
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
+        await guard.redis.set(f"strategy_switch:count:{today}", str(MAX_DAILY_SWITCHES - 1))
+        result = await guard.validate_switch("GOLD", "breakout")
+        assert result.allowed
+
+
+# ─── Record switch ──────────────────────────────────────────────────────────
+
+
+class TestRecordSwitch:
+    @pytest.mark.asyncio
+    async def test_records_switch(self, guard):
+        await guard.record_switch("GOLD", "breakout", "Regime changed to trending")
+
+        current = await guard.redis.get("strategy_switch:current:GOLD")
+        assert current is not None
+        current_name = current.decode() if isinstance(current, bytes) else str(current)
+        assert current_name == "breakout"
+
+        last = await guard.redis.get("strategy_switch:last:GOLD")
+        assert last is not None
+
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
+        count = await guard.redis.get(f"strategy_switch:count:{today}")
+        assert count is not None
+        count_val = int(count.decode() if isinstance(count, bytes) else str(count))
+        assert count_val == 1
+
+    @pytest.mark.asyncio
+    async def test_increments_daily_counter(self, guard):
+        await guard.record_switch("GOLD", "breakout", "reason1")
+        await guard.record_switch("GOLD", "ema_crossover", "reason2")
+
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
+        count = await guard.redis.get(f"strategy_switch:count:{today}")
+        count_val = int(count.decode() if isinstance(count, bytes) else str(count))
+        assert count_val == 2
+
+
+# ─── Get status ─────────────────────────────────────────────────────────────
+
+
+class TestGetStatus:
+    @pytest.mark.asyncio
+    async def test_default_status(self, guard):
+        status = await guard.get_status("GOLD")
+        assert status["enabled"] is False
+        assert status["current_strategy"] is None
+        assert status["daily_switches"] == 0
+        assert status["max_daily"] == MAX_DAILY_SWITCHES
+        assert status["cooldown_s"] == COOLDOWN_SECONDS
+
+    @pytest.mark.asyncio
+    async def test_status_after_switch(self, guard):
+        await guard.redis.set("enable_auto_strategy_switch", "1")
+        await guard.record_switch("GOLD", "breakout", "trending detected")
+
+        status = await guard.get_status("GOLD")
+        assert status["enabled"] is True
+        assert status["current_strategy"] == "breakout"
+        assert status["daily_switches"] == 1
+        assert status["last_switch"] is not None
+        assert status["cooldown_remaining_s"] > 0

--- a/frontend/app/backtest/page.tsx
+++ b/frontend/app/backtest/page.tsx
@@ -1079,7 +1079,7 @@ export default function BacktestPage() {
                   const pct = Number(h.overfitting_pct);
                   const grade = String(h.grade);
                   return (
-                    <div key={i} className="flex items-center gap-3">
+                    <div key={`${String(h.strategy)}-${String(h.symbol)}`} className="flex items-center gap-3">
                       <span className="text-sm w-32 truncate">{String(h.strategy)}</span>
                       <div className="flex-1 h-4 bg-muted rounded-full overflow-hidden">
                         <div

--- a/frontend/app/backtest/page.tsx
+++ b/frontend/app/backtest/page.tsx
@@ -8,7 +8,8 @@ import { Badge } from "@/components/ui/badge";
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsContent } from "@/components/ui/tabs";
+import type { LucideIcon } from "lucide-react";
 import {
   Play, BarChart3, TrendingUp, DollarSign, Target,
   AlertTriangle, Search, Loader2, FlaskConical, Zap, Footprints,
@@ -145,6 +146,8 @@ export default function BacktestPage() {
   const [ofResult, setOfResult] = useState<Record<string, unknown> | null>(null);
   const [ofRunning, setOfRunning] = useState(false);
   const [ofHistory, setOfHistory] = useState<Record<string, unknown>[]>([]);
+  // Active tab
+  const [activeTab, setActiveTab] = useState("backtest");
 
   const currentParams: ParamDef[] = STRATEGY_PARAMS[strategy] ?? [];
 
@@ -357,15 +360,35 @@ export default function BacktestPage() {
         ]}
       />
 
-      <Tabs defaultValue="backtest" className="space-y-5">
-        <TabsList className="flex w-full overflow-x-auto max-w-2xl">
-          <TabsTrigger value="backtest"><FlaskConical className="size-3.5 mr-1.5" />Backtest</TabsTrigger>
-          <TabsTrigger value="optimize"><Zap className="size-3.5 mr-1.5" />Optimizer</TabsTrigger>
-          <TabsTrigger value="walk-forward"><Footprints className="size-3.5 mr-1.5" />Walk Forward</TabsTrigger>
-          <TabsTrigger value="monte-carlo"><Dice5 className="size-3.5 mr-1.5" />Monte Carlo</TabsTrigger>
-          <TabsTrigger value="significance"><CheckCircle className="size-3.5 mr-1.5" />Significance</TabsTrigger>
-          <TabsTrigger value="overfitting"><AlertTriangle className="size-3.5 mr-1.5" />Overfitting</TabsTrigger>
-        </TabsList>
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-5">
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          {([
+            { value: "backtest", label: "Backtest", icon: FlaskConical },
+            { value: "optimize", label: "Optimizer", icon: Zap },
+            { value: "walk-forward", label: "Walk Forward", icon: Footprints },
+            { value: "monte-carlo", label: "Monte Carlo", icon: Dice5 },
+            { value: "significance", label: "Significance", icon: CheckCircle },
+            { value: "overfitting", label: "Overfitting", icon: AlertTriangle },
+          ] as { value: string; label: string; icon: LucideIcon }[]).map((tab) => {
+            const Icon = tab.icon;
+            const isActive = activeTab === tab.value;
+            return (
+              <button
+                key={tab.value}
+                type="button"
+                onClick={() => setActiveTab(tab.value)}
+                className={`flex items-center gap-2 min-h-11 px-4 py-2.5 rounded-xl border-2 text-xs font-semibold transition-all whitespace-nowrap ${
+                  isActive
+                    ? "bg-card text-primary border-primary"
+                    : "bg-card text-foreground border-border hover:border-primary/50"
+                }`}
+              >
+                <Icon className="size-3.5" />
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
 
         {/* ── Backtest Tab ─────────────────────────────────────── */}
         <TabsContent value="backtest" className="space-y-4 mt-0">

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -72,6 +72,7 @@ export default function SettingsPage() {
   const [readiness, setReadiness] = useState<{ ready: boolean; errors: number; warnings: number } | null>(null);
   const [confirmLive, setConfirmLive] = useState(false);
   const [strategies, setStrategies] = useState<{ name: string; worst_case: string }[]>([]);
+  const [autoStrategySwitch, setAutoStrategySwitch] = useState(false);
 
   const fetchAll = useCallback(async () => {
     try {
@@ -87,6 +88,9 @@ export default function SettingsPage() {
       }
       if (statusRes?.data?.symbols) {
         setSymbolStatuses(statusRes.data.symbols);
+      }
+      if (statusRes?.data?.enable_auto_strategy_switch !== undefined) {
+        setAutoStrategySwitch(statusRes.data.enable_auto_strategy_switch);
       }
       if (readinessRes?.data) {
         setChecks(readinessRes.data.checks || []);
@@ -173,6 +177,39 @@ export default function SettingsPage() {
           <p className="text-[11px] text-muted-foreground mt-2">
             Strategy สร้าง signal → AI filter ดูข่าว/event → Risk manager ตรวจ regime/drawdown → เปิด trade
           </p>
+        </CardContent>
+      </Card>
+
+      {/* ── Auto Strategy Switch ────────────────────────────── */}
+      <Card>
+        <CardHeader className="p-4 sm:p-6">
+          <CardTitle className="text-sm font-bold flex items-center gap-2">
+            <RefreshCw className="size-4" />
+            AI Auto Strategy Switch
+            <Badge variant="outline" className="text-[10px]">Beta</Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-4 pt-0 sm:p-6 sm:pt-0">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-sm">Allow AI to switch strategies based on market regime</p>
+              <p className="text-xs text-muted-foreground mt-1">
+                Cooldown 1h between switches, max 3/day. Respects rollout mode (shadow/paper = log only).
+              </p>
+            </div>
+            <Switch
+              checked={autoStrategySwitch}
+              onCheckedChange={async (v) => {
+                try {
+                  await updateSettings({ enable_auto_strategy_switch: v });
+                  setAutoStrategySwitch(v);
+                  showSuccess(v ? "Auto strategy switch enabled" : "Auto strategy switch disabled");
+                } catch {
+                  showError("Failed to update setting");
+                }
+              }}
+            />
+          </div>
         </CardContent>
       </Card>
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -53,6 +53,7 @@ export const updateSettings = (data: {
   max_lot?: number;
   fixed_lot?: number;
   lot_mode?: "fixed" | "auto";
+  enable_auto_strategy_switch?: boolean;
 }) => api.put("/api/bot/settings", data);
 export const getAccount = () => api.get("/api/bot/account");
 export const getBotEvents = (params?: { days?: number; event_type?: string; limit?: number }) =>


### PR DESCRIPTION
## Summary

- **Composite overfitting score**: combines walk-forward ratio (40%), permutation p-value (25%), param stability CV (20%), and Monte Carlo ruin prob (15%) into a single 0–100% score with letter grades. Exposed as MCP tool `compute_overfitting_score` + `POST /api/backtest/overfitting-score`. Frontend: new Overfitting tab on backtest page with gauge, grade badge, and component breakdown.
- **AI auto-strategy switch**: Reflector agent can now call `apply_strategy` to switch strategies based on regime detection. `PUT /api/bot/strategy-apply` sets a strategy without changing `trading_mode`, fixing the 48h silence where AI autonomous mode had no strategy object. Safety guardrails: cooldown 1h, max 3 switches/day, feature flag gated. Toggle on settings page (Beta).
- **Backtest UI**: pill-style tabs matching dashboard SymbolTabs.
- **Removed**: notification bell from sidebar.

## Test plan

- [ ] `pytest tests/unit/test_overfitting_score.py` — 26 tests pass
- [ ] `pytest tests/unit/test_strategy_switch_guard.py` — 15 tests pass
- [ ] Settings page: toggle "AI Auto Strategy Switch" → PUT /settings persists flag to Redis
- [ ] Call `apply_strategy` with flag OFF → rejected with "feature flag OFF"
- [ ] Call `apply_strategy` with flag ON → strategy applied, second call within 1h → cooldown rejection
- [ ] 4th switch in a day → daily limit rejection
- [ ] Backtest page: Overfitting tab renders score gauge + 4 component stat cards
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)