### PR TITLE
fix(reflector): apply strategy on initial assignment when no strategy is set

### DIFF
--- a/backend/mcp_server/agents/reflector.py
+++ b/backend/mcp_server/agents/reflector.py
@@ -43,7 +43,8 @@ After recommending a strategy via `recommend_strategy`, if it differs from the c
 - Use `apply_strategy` to switch. Include reasoning with evidence from regime + performance.
 - The tool enforces guards (cooldown 1h, max 3/day, feature flag).
 - If the tool returns {"applied": false}, respect the rejection and mention it in your report.
-- Only switch when regime has CLEARLY changed AND current strategy performance is degrading.
+- Use `apply_strategy` immediately if no strategy is currently set (get_switch_status returns current_strategy=null) — this is initial assignment, not a regime switch, so the "CLEARLY changed" rule does not apply.
+- Otherwise, only switch when regime has CLEARLY changed AND current strategy performance is degrading.
 - Use `get_switch_status` to check current switch state before attempting.
 
 ## Persistent Memory (Long-term Learning)


### PR DESCRIPTION
## Problem

After deploying in AI autonomous mode, the Reflector skipped calling `apply_strategy()` on the first run, leaving `engine.strategy = None` and causing the bot to HOLD indefinitely.

**Root cause:** The prompt said "only switch when regime has CLEARLY changed AND performance is degrading" — on a fresh start there's no history, so this condition could never be satisfied.

## Fix

Added an explicit rule: if `get_switch_status` returns `current_strategy=null` (no strategy set yet), call `apply_strategy` immediately. This is an initial assignment, not a regime switch, so the "CLEARLY changed" guard does not apply.

## Test plan

- [ ] Deploy → start bot in AI autonomous mode
- [ ] Verify Reflector calls `apply_strategy` on first candle cycle (Activity page)
- [ ] Verify `engine.strategy` is no longer None (bot starts trading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)