### PR TITLE
feat: symbol config management UI

### DIFF
--- a/backend/alembic/versions/q7r8s9t0u1v2_add_symbol_configs.py
+++ b/backend/alembic/versions/q7r8s9t0u1v2_add_symbol_configs.py
@@ -1,0 +1,151 @@
+"""add symbol_configs table
+
+Revision ID: q7r8s9t0u1v2
+Revises: p6q7r8s9t0u1
+Create Date: 2026-04-19 10:00:00.000000
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "q7r8s9t0u1v2"
+down_revision: str | None = "p6q7r8s9t0u1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Seed defaults mirror SYMBOL_PROFILES in app/config.py as of this migration.
+_SEED_ROWS = [
+    {
+        "symbol": "GOLD",
+        "display_name": "Gold (XAUUSD)",
+        "broker_alias": "GOLDmicro",
+        "is_enabled": True,
+        "default_timeframe": "M15",
+        "pip_value": 1.0,
+        "default_lot": 0.1,
+        "max_lot": 1.0,
+        "price_decimals": 2,
+        "sl_atr_mult": 1.5,
+        "tp_atr_mult": 2.0,
+        "contract_size": 100,
+        "ml_tp_pips": 10.0,
+        "ml_sl_pips": 10.0,
+        "ml_forward_bars": 10,
+        "ml_timeframe": "M15",
+    },
+    {
+        "symbol": "OILCash",
+        "display_name": "WTI Oil",
+        "broker_alias": "OILCashmicro",
+        "is_enabled": False,
+        "default_timeframe": "M15",
+        "pip_value": 10.0,
+        "default_lot": 0.1,
+        "max_lot": 5.0,
+        "price_decimals": 2,
+        "sl_atr_mult": 1.5,
+        "tp_atr_mult": 2.0,
+        "contract_size": 100,
+        "ml_tp_pips": 0.5,
+        "ml_sl_pips": 0.5,
+        "ml_forward_bars": 10,
+        "ml_timeframe": "M15",
+    },
+    {
+        "symbol": "BTCUSD",
+        "display_name": "Bitcoin",
+        "broker_alias": "BTCUSDmicro",
+        "is_enabled": False,
+        "default_timeframe": "M15",
+        "pip_value": 1.0,
+        "default_lot": 0.01,
+        "max_lot": 0.5,
+        "price_decimals": 2,
+        "sl_atr_mult": 2.0,
+        "tp_atr_mult": 3.0,
+        "contract_size": 1,
+        "ml_tp_pips": 500.0,
+        "ml_sl_pips": 500.0,
+        "ml_forward_bars": 5,
+        "ml_timeframe": "H1",
+    },
+    {
+        "symbol": "USDJPY",
+        "display_name": "USD/JPY",
+        "broker_alias": "USDJPYmicro",
+        "is_enabled": False,
+        "default_timeframe": "M15",
+        "pip_value": 100.0,
+        "default_lot": 0.1,
+        "max_lot": 5.0,
+        "price_decimals": 3,
+        "sl_atr_mult": 1.5,
+        "tp_atr_mult": 2.0,
+        "contract_size": 100000,
+        "ml_tp_pips": 0.3,
+        "ml_sl_pips": 0.3,
+        "ml_forward_bars": 10,
+        "ml_timeframe": "M15",
+    },
+]
+
+
+def upgrade() -> None:
+    op.execute("SET lock_timeout = '30s'")
+    op.create_table(
+        "symbol_configs",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("symbol", sa.String(32), nullable=False),
+        sa.Column("display_name", sa.String(64), nullable=False),
+        sa.Column("broker_alias", sa.String(32), nullable=True),
+        sa.Column("is_enabled", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("is_deleted", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("default_timeframe", sa.String(8), nullable=False, server_default="M15"),
+        sa.Column("pip_value", sa.Float(), nullable=False),
+        sa.Column("default_lot", sa.Float(), nullable=False),
+        sa.Column("max_lot", sa.Float(), nullable=False),
+        sa.Column("price_decimals", sa.Integer(), nullable=False, server_default="2"),
+        sa.Column("sl_atr_mult", sa.Float(), nullable=False, server_default="1.5"),
+        sa.Column("tp_atr_mult", sa.Float(), nullable=False, server_default="2.0"),
+        sa.Column("contract_size", sa.Float(), nullable=False, server_default="1.0"),
+        sa.Column("ml_tp_pips", sa.Float(), nullable=False),
+        sa.Column("ml_sl_pips", sa.Float(), nullable=False),
+        sa.Column("ml_forward_bars", sa.Integer(), nullable=False, server_default="10"),
+        sa.Column("ml_timeframe", sa.String(8), nullable=False, server_default="M15"),
+        sa.Column("ml_status", sa.String(16), nullable=False, server_default="pending"),
+        sa.Column("ml_last_trained_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_by", sa.String(128), nullable=True),
+        sa.UniqueConstraint("symbol", name="uq_symbol_configs_symbol"),
+    )
+    op.create_index("ix_symbol_configs_symbol", "symbol_configs", ["symbol"])
+
+    bind = op.get_bind()
+    table = sa.table(
+        "symbol_configs",
+        sa.column("symbol", sa.String),
+        sa.column("display_name", sa.String),
+        sa.column("broker_alias", sa.String),
+        sa.column("is_enabled", sa.Boolean),
+        sa.column("default_timeframe", sa.String),
+        sa.column("pip_value", sa.Float),
+        sa.column("default_lot", sa.Float),
+        sa.column("max_lot", sa.Float),
+        sa.column("price_decimals", sa.Integer),
+        sa.column("sl_atr_mult", sa.Float),
+        sa.column("tp_atr_mult", sa.Float),
+        sa.column("contract_size", sa.Float),
+        sa.column("ml_tp_pips", sa.Float),
+        sa.column("ml_sl_pips", sa.Float),
+        sa.column("ml_forward_bars", sa.Integer),
+        sa.column("ml_timeframe", sa.String),
+    )
+    bind.execute(table.insert(), _SEED_ROWS)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_symbol_configs_symbol", "symbol_configs")
+    op.drop_table("symbol_configs")

--- a/backend/app/api/routes/symbols.py
+++ b/backend/app/api/routes/symbols.py
@@ -1,0 +1,279 @@
+"""Symbol Config API — CRUD + toggle + MT5 validation + ML retrain trigger."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from datetime import datetime
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator, model_validator
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit import log_audit
+from app.auth import require_auth
+from app.db.models import SymbolConfig
+from app.db.session import get_db
+from app.services import symbol_config_service as svc
+
+router = APIRouter(prefix="/api/symbols", tags=["symbols"])
+
+
+Timeframe = Literal["M1", "M5", "M15", "M30", "H1", "H4", "D1"]
+MLStatus = Literal["pending", "training", "ready", "failed"]
+_SYMBOL_PATTERN = re.compile(r"^[A-Za-z0-9._-]{2,32}$")
+
+
+# ─── Schemas ──────────────────────────────────────────────────────────────────
+
+
+class SymbolBase(BaseModel):
+    display_name: str = Field(min_length=1, max_length=64)
+    broker_alias: str | None = None
+    default_timeframe: Timeframe = "M15"
+    pip_value: float = Field(gt=0)
+    default_lot: float = Field(gt=0)
+    max_lot: float = Field(gt=0)
+    price_decimals: int = Field(ge=0, le=8, default=2)
+    sl_atr_mult: float = Field(gt=0, le=10, default=1.5)
+    tp_atr_mult: float = Field(gt=0, le=10, default=2.0)
+    contract_size: float = Field(gt=0, default=1.0)
+    ml_tp_pips: float = Field(gt=0)
+    ml_sl_pips: float = Field(gt=0)
+    ml_forward_bars: int = Field(ge=1, le=100, default=10)
+    ml_timeframe: Timeframe = "M15"
+
+    @model_validator(mode="after")
+    def _check_lot_bounds(self) -> "SymbolBase":
+        if self.default_lot > self.max_lot:
+            raise ValueError("default_lot must be <= max_lot")
+        return self
+
+
+class SymbolCreateRequest(SymbolBase):
+    symbol: str = Field(min_length=2, max_length=32)
+
+    @field_validator("symbol")
+    @classmethod
+    def _check_symbol(cls, v: str) -> str:
+        if not _SYMBOL_PATTERN.match(v):
+            raise ValueError("symbol must be alphanumeric (2-32 chars, . _ - allowed)")
+        return v
+
+
+class SymbolUpdateRequest(SymbolBase):
+    pass
+
+
+class SymbolResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    symbol: str
+    display_name: str
+    broker_alias: str | None
+    is_enabled: bool
+    default_timeframe: str
+    pip_value: float
+    default_lot: float
+    max_lot: float
+    price_decimals: int
+    sl_atr_mult: float
+    tp_atr_mult: float
+    contract_size: float
+    ml_tp_pips: float
+    ml_sl_pips: float
+    ml_forward_bars: int
+    ml_timeframe: str
+    ml_status: str
+    ml_last_trained_at: datetime | None
+    created_at: datetime | None
+    updated_at: datetime | None
+
+    @field_serializer("ml_last_trained_at", "created_at", "updated_at")
+    def _ser_dt(self, v: datetime | None) -> str | None:
+        return v.isoformat() if v else None
+
+
+class SymbolSpecResponse(BaseModel):
+    ok: bool
+    message: str
+    spec: dict | None = None
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+async def _require_config(db: AsyncSession, symbol: str) -> SymbolConfig:
+    cfg = await svc.get_config(db, symbol)
+    if not cfg:
+        raise HTTPException(status_code=404, detail=f"Symbol '{symbol}' not found")
+    return cfg
+
+
+async def _audit(
+    db: AsyncSession,
+    request: Request,
+    action: str,
+    symbol: str,
+    detail: dict | None = None,
+) -> None:
+    await log_audit(
+        db, action, resource=f"symbol:{symbol}",
+        detail=detail,
+        ip=request.client.host if request.client else None,
+        auto_commit=False,
+    )
+
+
+async def _publish(request: Request, symbol: str, action: str) -> None:
+    redis_client = getattr(request.app.state, "redis", None)
+    if redis_client:
+        await svc.publish_reload(redis_client, symbol, action)
+
+
+# ─── Endpoints ────────────────────────────────────────────────────────────────
+
+
+@router.get("", dependencies=[Depends(require_auth)])
+async def list_symbols(db: AsyncSession = Depends(get_db)) -> list[SymbolResponse]:
+    configs = await svc.list_configs(db)
+    return [SymbolResponse.model_validate(c) for c in configs]
+
+
+@router.get("/{symbol}", dependencies=[Depends(require_auth)])
+async def get_symbol(symbol: str, db: AsyncSession = Depends(get_db)) -> SymbolResponse:
+    cfg = await _require_config(db, symbol)
+    return SymbolResponse.model_validate(cfg)
+
+
+@router.post("", dependencies=[Depends(require_auth)])
+async def create_symbol(
+    req: SymbolCreateRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> SymbolResponse:
+    if await svc.get_config(db, req.symbol):
+        raise HTTPException(status_code=409, detail=f"Symbol '{req.symbol}' already exists")
+
+    cfg = SymbolConfig(**req.model_dump(), is_enabled=False, ml_status="pending")
+    db.add(cfg)
+    await _audit(db, request, "symbol_created", req.symbol, {"broker_alias": req.broker_alias})
+    await db.commit()
+    await db.refresh(cfg)
+    await _publish(request, req.symbol, "created")
+
+    logger.info(f"Symbol created: {req.symbol}")
+    return SymbolResponse.model_validate(cfg)
+
+
+@router.put("/{symbol}", dependencies=[Depends(require_auth)])
+async def update_symbol(
+    symbol: str,
+    req: SymbolUpdateRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> SymbolResponse:
+    cfg = await _require_config(db, symbol)
+    for field, value in req.model_dump().items():
+        setattr(cfg, field, value)
+    cfg.updated_at = datetime.utcnow()
+
+    await _audit(db, request, "symbol_updated", symbol)
+    await db.commit()
+    await db.refresh(cfg)
+    await _publish(request, symbol, "updated")
+
+    return SymbolResponse.model_validate(cfg)
+
+
+@router.delete("/{symbol}", dependencies=[Depends(require_auth)])
+async def delete_symbol(
+    symbol: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    cfg = await _require_config(db, symbol)
+    cfg.is_enabled = False
+    cfg.is_deleted = True
+    cfg.updated_at = datetime.utcnow()
+
+    await _audit(db, request, "symbol_deleted", symbol)
+    await db.commit()
+    await _publish(request, symbol, "deleted")
+
+    return {"status": "deleted", "symbol": symbol}
+
+
+@router.post("/{symbol}/toggle", dependencies=[Depends(require_auth)])
+async def toggle_symbol(
+    symbol: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> SymbolResponse:
+    cfg = await _require_config(db, symbol)
+    cfg.is_enabled = not cfg.is_enabled
+    cfg.updated_at = datetime.utcnow()
+
+    action = "symbol_enabled" if cfg.is_enabled else "symbol_disabled"
+    await _audit(db, request, action, symbol)
+    await db.commit()
+    await db.refresh(cfg)
+    await _publish(request, symbol, "toggled")
+
+    logger.info(f"Symbol {symbol} -> enabled={cfg.is_enabled}")
+    return SymbolResponse.model_validate(cfg)
+
+
+@router.post("/{symbol}/validate", dependencies=[Depends(require_auth)])
+async def validate_symbol(
+    symbol: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> SymbolSpecResponse:
+    cfg = await svc.get_config(db, symbol)
+    alias = cfg.broker_alias if cfg and cfg.broker_alias else symbol
+    connector = getattr(request.app.state, "connector", None)
+    if connector is None:
+        raise HTTPException(status_code=503, detail="MT5 connector unavailable")
+
+    result = await connector.get_symbol_spec(alias)
+    if not result.get("success"):
+        return SymbolSpecResponse(ok=False, message=result.get("error") or "unknown error")
+    return SymbolSpecResponse(ok=True, message=f"Validated {alias}", spec=result.get("data"))
+
+
+@router.post("/{symbol}/retrain", dependencies=[Depends(require_auth)])
+async def retrain_symbol(
+    symbol: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    cfg = await _require_config(db, symbol)
+    if cfg.ml_status == "training":
+        raise HTTPException(status_code=409, detail=f"Symbol '{symbol}' already training")
+
+    scheduler = getattr(request.app.state, "scheduler", None)
+    manager = getattr(request.app.state, "manager", None)
+    engine = manager.get_engine(symbol) if manager else None
+    if scheduler is None or engine is None:
+        raise HTTPException(status_code=503, detail="Scheduler or engine unavailable")
+
+    cfg.ml_status = "training"
+    cfg.updated_at = datetime.utcnow()
+    await db.commit()
+
+    asyncio.create_task(scheduler._ml_retrain_symbol(symbol, engine))
+
+    return {"status": "training", "symbol": symbol}
+
+
+@router.get("/{symbol}/ml-status", dependencies=[Depends(require_auth)])
+async def get_ml_status(symbol: str, db: AsyncSession = Depends(get_db)) -> dict:
+    cfg = await _require_config(db, symbol)
+    return {
+        "symbol": symbol,
+        "status": cfg.ml_status,
+        "last_trained_at": cfg.ml_last_trained_at.isoformat() if cfg.ml_last_trained_at else None,
+    }

--- a/backend/app/api/routes/symbols.py
+++ b/backend/app/api/routes/symbols.py
@@ -179,6 +179,7 @@ async def update_symbol(
     for field, value in req.model_dump().items():
         setattr(cfg, field, value)
     cfg.updated_at = datetime.utcnow()
+    cfg.updated_by = "owner"
 
     await _audit(db, request, "symbol_updated", symbol)
     await db.commit()
@@ -198,6 +199,7 @@ async def delete_symbol(
     cfg.is_enabled = False
     cfg.is_deleted = True
     cfg.updated_at = datetime.utcnow()
+    cfg.updated_by = "owner"
 
     await _audit(db, request, "symbol_deleted", symbol)
     await db.commit()
@@ -215,6 +217,7 @@ async def toggle_symbol(
     cfg = await _require_config(db, symbol)
     cfg.is_enabled = not cfg.is_enabled
     cfg.updated_at = datetime.utcnow()
+    cfg.updated_by = "owner"
 
     action = "symbol_enabled" if cfg.is_enabled else "symbol_disabled"
     await _audit(db, request, action, symbol)
@@ -262,11 +265,26 @@ async def retrain_symbol(
 
     cfg.ml_status = "training"
     cfg.updated_at = datetime.utcnow()
+    cfg.updated_by = "owner"
     await db.commit()
 
-    asyncio.create_task(scheduler._ml_retrain_symbol(symbol, engine))
+    task = asyncio.create_task(scheduler._ml_retrain_symbol(symbol, engine))
+    _retrain_tasks.add(task)
+    task.add_done_callback(_on_retrain_done)
 
     return {"status": "training", "symbol": symbol}
+
+
+_retrain_tasks: set[asyncio.Task] = set()
+
+
+def _on_retrain_done(task: asyncio.Task) -> None:
+    _retrain_tasks.discard(task)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error(f"retrain task raised: {exc!r}")
 
 
 @router.get("/{symbol}/ml-status", dependencies=[Depends(require_auth)])

--- a/backend/app/bot/engine.py
+++ b/backend/app/bot/engine.py
@@ -109,8 +109,8 @@ class BotEngine:
         self.db = db_session
         self.redis = redis_client
 
-        # Symbol profile (per-symbol config)
         profile = symbol_profile or {}
+        self.symbol_profile = profile
         self.symbol = symbol or settings.symbol
         self.timeframe = profile.get("default_timeframe", settings.timeframe)
         self.contract_size = profile.get("contract_size", 100)
@@ -170,6 +170,18 @@ class BotEngine:
         self._position_breakeven: set[int] = set()  # tickets moved to breakeven
         self.started_at: datetime | None = None
         self.last_signal_time: datetime | None = None
+
+    def apply_profile(self, profile: dict) -> None:
+        """Update engine + risk manager params from a profile dict (hot-reload path)."""
+        self.symbol_profile = profile
+        self.timeframe = profile.get("default_timeframe", self.timeframe)
+        self.contract_size = profile.get("contract_size", self.contract_size)
+        rm = self.risk_manager
+        rm.pip_value = profile.get("pip_value", rm.pip_value)
+        rm.price_decimals = profile.get("price_decimals", rm.price_decimals)
+        rm.sl_atr_mult = profile.get("sl_atr_mult", rm.sl_atr_mult)
+        rm.tp_atr_mult = profile.get("tp_atr_mult", rm.tp_atr_mult)
+        rm.max_lot = profile.get("max_lot", rm.max_lot)
 
     def set_sentiment_analyzer(self, analyzer: NewsSentimentAnalyzer):
         self.sentiment_analyzer = analyzer

--- a/backend/app/bot/manager.py
+++ b/backend/app/bot/manager.py
@@ -36,19 +36,20 @@ class BotManager:
         self._sentiment_analyzer = None
         self._notifier = None
         self._binance_connector = None
-        # Validate symbol profiles exist
-        for symbol in settings.symbol_list:
+        # Prefer DB-sourced enable flags; fall back to env-var symbol list when empty.
+        db_enabled = [
+            s for s, p in SYMBOL_PROFILES.items()
+            if p.get("is_enabled") is True and "canonical" not in p
+        ]
+        initial = db_enabled or settings.symbol_list
+        for symbol in initial:
             if symbol not in SYMBOL_PROFILES:
                 logger.warning(f"BotManager: Symbol '{symbol}' missing from SYMBOL_PROFILES — using defaults (review contract_size!)")
 
-        # Create an engine for each configured symbol (all use MT5 Bridge)
-        for symbol in settings.symbol_list:
+        for symbol in initial:
             profile = SYMBOL_PROFILES.get(symbol, {})
-            sym_connector = connector
-            logger.info(f"BotManager: {symbol} → MT5 Bridge")
-
             engine = BotEngine(
-                connector=sym_connector,
+                connector=connector,
                 db_session=db_session,
                 redis_client=redis_client,
                 symbol=symbol,

--- a/backend/app/bot/manager.py
+++ b/backend/app/bot/manager.py
@@ -10,8 +10,11 @@ from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.bot.engine import BotEngine
-from app.config import SYMBOL_PROFILES, settings
+from app.config import SYMBOL_PROFILES, apply_db_symbol_profiles, settings
+from app.db.session import async_session
 from app.mt5.connector import MT5BridgeConnector
+from app.services import symbol_config_service as symbol_svc
+from app.services.symbol_config_service import RELOAD_CHANNEL
 
 
 class BotManager:
@@ -29,6 +32,10 @@ class BotManager:
         self.engines: dict[str, BotEngine] = {}
         self._positions_cache: dict[str, list[dict]] = {}
         self._positions_cache_time: float = 0
+        self._reload_task: asyncio.Task | None = None
+        self._sentiment_analyzer = None
+        self._notifier = None
+        self._binance_connector = None
         # Validate symbol profiles exist
         for symbol in settings.symbol_list:
             if symbol not in SYMBOL_PROFILES:
@@ -159,6 +166,115 @@ class BotManager:
             return False, reason
         return True, "OK"
 
+    def _build_engine(self, symbol: str, profile: dict) -> BotEngine:
+        engine = BotEngine(
+            connector=self.connector,
+            db_session=self.db,
+            redis_client=self.redis,
+            symbol=symbol,
+            symbol_profile=profile,
+        )
+        engine._manager = self
+        if self._sentiment_analyzer:
+            engine.set_sentiment_analyzer(self._sentiment_analyzer)
+        if self._notifier:
+            engine.set_notifier(self._notifier)
+        return engine
+
+    async def reload_engines(self) -> dict:
+        """Rebuild engine set from current SYMBOL_PROFILES + is_enabled flags."""
+        enabled = {
+            s for s, p in SYMBOL_PROFILES.items()
+            if p.get("is_enabled") is True and "canonical" not in p
+        }
+        if not enabled:
+            # Backward compat: fall back to env-var symbol list when DB empty.
+            enabled = set(settings.symbol_list)
+
+        current = set(self.engines.keys())
+        to_add = enabled - current
+        to_remove = current - enabled
+        to_update = enabled & current
+
+        stop_coros = [self.engines.pop(s).stop() for s in to_remove]
+        if stop_coros:
+            await asyncio.gather(*stop_coros, return_exceptions=True)
+
+        for symbol in to_add:
+            try:
+                self.engines[symbol] = self._build_engine(symbol, SYMBOL_PROFILES.get(symbol, {}))
+            except Exception as e:
+                logger.error(f"BotManager: create {symbol} failed: {e}")
+
+        for symbol in to_update:
+            profile = SYMBOL_PROFILES.get(symbol)
+            if profile:
+                self.engines[symbol].apply_profile(profile)
+
+        summary = {
+            "added": sorted(to_add),
+            "removed": sorted(to_remove),
+            "updated": sorted(to_update),
+            "active": sorted(self.engines.keys()),
+        }
+        logger.info(f"BotManager reload: {summary}")
+        return summary
+
+    async def _apply_db_and_reload(self) -> None:
+        async with async_session() as session:
+            db_profiles = await symbol_svc.load_profiles_from_db(session)
+        apply_db_symbol_profiles(db_profiles)
+        await self.reload_engines()
+
+    async def start_reload_subscriber(self, debounce_seconds: float = 0.3) -> None:
+        """Subscribe to Redis reload channel; coalesce bursts within debounce window."""
+        if self._reload_task and not self._reload_task.done():
+            return
+
+        async def _run() -> None:
+            backoff = 1.0
+            while True:
+                pubsub = self.redis.pubsub()
+                try:
+                    await pubsub.subscribe(RELOAD_CHANNEL)
+                    logger.info(f"BotManager: subscribed to {RELOAD_CHANNEL}")
+                    backoff = 1.0
+                    async for msg in pubsub.listen():
+                        if msg.get("type") != "message":
+                            continue
+                        # Drain any additional messages that arrived in the debounce window
+                        await asyncio.sleep(debounce_seconds)
+                        while True:
+                            extra = await pubsub.get_message(ignore_subscribe_messages=True, timeout=0.01)
+                            if not extra:
+                                break
+                        try:
+                            await self._apply_db_and_reload()
+                        except Exception as e:
+                            logger.error(f"BotManager reload handler failed: {e}")
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.warning(f"BotManager subscriber error (retrying in {backoff:.0f}s): {e}")
+                    await asyncio.sleep(backoff)
+                    backoff = min(backoff * 2, 60.0)
+                finally:
+                    try:
+                        await pubsub.unsubscribe(RELOAD_CHANNEL)
+                        await pubsub.aclose()
+                    except Exception:
+                        pass
+
+        self._reload_task = asyncio.create_task(_run())
+
+    async def stop_reload_subscriber(self) -> None:
+        if self._reload_task and not self._reload_task.done():
+            self._reload_task.cancel()
+            try:
+                await self._reload_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
     def set_sentiment_analyzer(self, analyzer, symbol: str | None = None):
         """Set sentiment analyzer on one or all engines."""
         if symbol:
@@ -166,6 +282,7 @@ class BotManager:
             if engine:
                 engine.set_sentiment_analyzer(analyzer)
         else:
+            self._sentiment_analyzer = analyzer
             for engine in self.engines.values():
                 engine.set_sentiment_analyzer(analyzer)
 
@@ -176,5 +293,6 @@ class BotManager:
             if engine:
                 engine.set_notifier(notifier)
         else:
+            self._notifier = notifier
             for engine in self.engines.values():
                 engine.set_notifier(notifier)

--- a/backend/app/bot/scheduler.py
+++ b/backend/app/bot/scheduler.py
@@ -679,6 +679,24 @@ class BotScheduler:
         except Exception as e:
             logger.warning(f"Vault health check failed: {e}")
 
+    async def _set_symbol_ml_status(self, symbol: str, status: str, mark_trained: bool = False) -> None:
+        """Write ml_status back to symbol_configs so the UI badge reflects reality."""
+        try:
+            from sqlalchemy import update
+            from app.db.models import SymbolConfig
+            from app.db.session import async_session
+
+            values = {"ml_status": status, "updated_at": datetime.utcnow()}
+            if mark_trained:
+                values["ml_last_trained_at"] = datetime.utcnow()
+            async with async_session() as session:
+                await session.execute(
+                    update(SymbolConfig).where(SymbolConfig.symbol == symbol).values(**values)
+                )
+                await session.commit()
+        except Exception as e:
+            logger.warning(f"ml_status writeback [{symbol}] failed: {e}")
+
     async def _ml_retrain_symbol(self, symbol: str, engine):
         """Train ML model for a single symbol."""
         try:
@@ -715,6 +733,7 @@ class BotScheduler:
 
                 if df.empty or len(df) < 500:
                     logger.warning(f"ML retrain [{symbol}] skipped: insufficient data ({len(df)} bars)")
+                    await self._set_symbol_ml_status(symbol, "failed")
                     return
 
                 macro_df = None
@@ -738,6 +757,7 @@ class BotScheduler:
             X, y = trainer.prepare_dataset(df, macro_df=macro_df, sentiment_df=sentiment_df)
             if len(X) < 200:
                 logger.warning(f"ML retrain [{symbol}] skipped: insufficient labeled samples ({len(X)})")
+                await self._set_symbol_ml_status(symbol, "failed")
                 return
 
             split_idx = int(len(X) * 0.85)
@@ -808,5 +828,8 @@ class BotScheduler:
                 except Exception:
                     pass
 
+            await self._set_symbol_ml_status(symbol, "ready", mark_trained=True)
+
         except Exception as e:
             logger.error(f"ML retrain [{symbol}] error: {e}")
+            await self._set_symbol_ml_status(symbol, "failed")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -116,6 +116,26 @@ for _alias, _canonical in SYMBOL_ALIASES.items():
         SYMBOL_PROFILES[_alias] = _profile
 
 
+# Snapshot static defaults so repeated reloads can restore them before merging DB rows.
+_STATIC_SYMBOL_PROFILES: dict[str, dict] = {k: v.copy() for k, v in SYMBOL_PROFILES.items()}
+
+
+def apply_db_symbol_profiles(db_profiles: dict[str, dict]) -> None:
+    """Replace SYMBOL_PROFILES with static defaults overridden by DB entries."""
+    SYMBOL_PROFILES.clear()
+    SYMBOL_PROFILES.update(_STATIC_SYMBOL_PROFILES)
+    SYMBOL_PROFILES.update(db_profiles)
+
+
+def get_enabled_symbols_override() -> list[str] | None:
+    """Return enabled canonical symbols, or None if none are marked enabled."""
+    enabled = [
+        s for s, p in SYMBOL_PROFILES.items()
+        if p.get("is_enabled") is True and "canonical" not in p
+    ]
+    return enabled or None
+
+
 # Session profiles — SL/TP multiplier overrides by trading session
 SESSION_PROFILES = {
     "asian":   {"hours": (0, 8),   "sl_atr_mult": 1.2, "tp_atr_mult": 1.5, "confidence_boost": 0.05},

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -127,15 +127,6 @@ def apply_db_symbol_profiles(db_profiles: dict[str, dict]) -> None:
     SYMBOL_PROFILES.update(db_profiles)
 
 
-def get_enabled_symbols_override() -> list[str] | None:
-    """Return enabled canonical symbols, or None if none are marked enabled."""
-    enabled = [
-        s for s, p in SYMBOL_PROFILES.items()
-        if p.get("is_enabled") is True and "canonical" not in p
-    ]
-    return enabled or None
-
-
 # Session profiles — SL/TP multiplier overrides by trading session
 SESSION_PROFILES = {
     "asian":   {"hours": (0, 8),   "sl_atr_mult": 1.2, "tp_atr_mult": 1.5, "confidence_boost": 0.05},

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -390,6 +390,38 @@ class AgentMemory(Base):
     updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
 
 
+class SymbolConfig(Base):
+    """User-managed symbol trading config — replaces static SYMBOL_PROFILES when present."""
+    __tablename__ = "symbol_configs"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    symbol: Mapped[str] = mapped_column(String(32), unique=True, index=True)
+    display_name: Mapped[str] = mapped_column(String(64))
+    broker_alias: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    is_enabled: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
+    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
+
+    default_timeframe: Mapped[str] = mapped_column(String(8), default="M15", server_default="M15")
+    pip_value: Mapped[float] = mapped_column(Float)
+    default_lot: Mapped[float] = mapped_column(Float)
+    max_lot: Mapped[float] = mapped_column(Float)
+    price_decimals: Mapped[int] = mapped_column(Integer, default=2, server_default="2")
+    sl_atr_mult: Mapped[float] = mapped_column(Float, default=1.5, server_default="1.5")
+    tp_atr_mult: Mapped[float] = mapped_column(Float, default=2.0, server_default="2.0")
+    contract_size: Mapped[float] = mapped_column(Float, default=1.0, server_default="1.0")
+    ml_tp_pips: Mapped[float] = mapped_column(Float)
+    ml_sl_pips: Mapped[float] = mapped_column(Float)
+    ml_forward_bars: Mapped[int] = mapped_column(Integer, default=10, server_default="10")
+    ml_timeframe: Mapped[str] = mapped_column(String(8), default="M15", server_default="M15")
+
+    ml_status: Mapped[str] = mapped_column(String(16), default="pending", server_default="pending")
+    ml_last_trained_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    updated_by: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+
+
 class AIUsageLog(Base):
     __tablename__ = "ai_usage_logs"
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -131,8 +131,6 @@ async def lifespan(app: FastAPI):
         if db_profiles:
             apply_db_symbol_profiles(db_profiles)
             enabled = [s for s, p in db_profiles.items() if p.get("is_enabled") and "canonical" not in p]
-            if enabled:
-                settings.symbols = ",".join(enabled)
             logger.info(f"Symbol profiles loaded from DB: {len(db_profiles)} entries, enabled: {enabled}")
     except Exception as e:
         logger.warning(f"Symbol profile DB load failed (using static defaults): {e}")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,6 +36,7 @@ from app.api.routes import (
     runners,
     secrets,
     strategy,
+    symbols as symbols_routes,
 )
 from app.api.routes import quant
 from app.api.routes import metrics as metrics_routes
@@ -121,6 +122,20 @@ async def lifespan(app: FastAPI):
 
     # Create a persistent DB session for bot engines
     db_session = async_session()
+
+    try:
+        from app.services import symbol_config_service as symbol_svc
+        from app.config import apply_db_symbol_profiles
+        async with async_session() as _cfg_session:
+            db_profiles = await symbol_svc.load_profiles_from_db(_cfg_session)
+        if db_profiles:
+            apply_db_symbol_profiles(db_profiles)
+            enabled = [s for s, p in db_profiles.items() if p.get("is_enabled") and "canonical" not in p]
+            if enabled:
+                settings.symbols = ",".join(enabled)
+            logger.info(f"Symbol profiles loaded from DB: {len(db_profiles)} entries, enabled: {enabled}")
+    except Exception as e:
+        logger.warning(f"Symbol profile DB load failed (using static defaults): {e}")
 
     # Initialize BotManager (creates one engine per symbol)
     manager = BotManager(connector, db_session, redis_client)
@@ -278,6 +293,9 @@ async def lifespan(app: FastAPI):
         logger.warning(f"Runner manager init failed (non-fatal): {e}")
         logger.warning("Runner features disabled — run 'alembic upgrade head' to create runner tables")
 
+    # Start symbol-config hot-reload subscriber
+    await manager.start_reload_subscriber()
+
     symbols = manager.get_symbols()
     logger.info(f"Trading Bot initialized — symbols: {symbols}")
 
@@ -290,6 +308,7 @@ async def lifespan(app: FastAPI):
     if "runner_db_session" in dir():
         await runner_db_session.close()
     scheduler.stop()
+    await manager.stop_reload_subscriber()
     await manager.stop()
     await connector.close()
     if manager._binance_connector:
@@ -371,6 +390,7 @@ app.include_router(agent_prompts.router)
 app.include_router(ai_usage.router)
 app.include_router(memory_routes.router)
 app.include_router(quant.router)
+app.include_router(symbols_routes.router)
 app.include_router(ws_router)
 app.include_router(ws_runners_router)
 

--- a/backend/app/mt5/connector.py
+++ b/backend/app/mt5/connector.py
@@ -89,6 +89,10 @@ class MT5BridgeConnector:
     async def get_ohlcv(self, symbol: str, timeframe: str = "M15", count: int = 100) -> dict:
         return await self._request("get", f"/ohlcv/{symbol}", params={"timeframe": timeframe, "count": count})
 
+    async def get_symbol_spec(self, symbol: str) -> dict:
+        """Fetch broker-side symbol spec (digits, volume limits, contract size)."""
+        return await self._request("get", f"/symbol-spec/{symbol}")
+
     async def get_account(self) -> dict:
         return await self._request("get", "/account")
 

--- a/backend/app/services/symbol_config_service.py
+++ b/backend/app/services/symbol_config_service.py
@@ -1,0 +1,86 @@
+"""SymbolConfigService — DB-backed symbol profiles with Redis pub/sub hot-reload."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+import redis.asyncio as redis
+from loguru import logger
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import SymbolConfig
+
+RELOAD_CHANNEL = "symbol_config_changed"
+
+
+def config_to_profile(cfg: SymbolConfig) -> dict:
+    """Convert DB row to in-memory profile dict (matches SYMBOL_PROFILES shape)."""
+    return {
+        "display_name": cfg.display_name,
+        "default_timeframe": cfg.default_timeframe,
+        "pip_value": cfg.pip_value,
+        "default_lot": cfg.default_lot,
+        "max_lot": cfg.max_lot,
+        "price_decimals": cfg.price_decimals,
+        "sl_atr_mult": cfg.sl_atr_mult,
+        "tp_atr_mult": cfg.tp_atr_mult,
+        "contract_size": cfg.contract_size,
+        "ml_tp_pips": cfg.ml_tp_pips,
+        "ml_sl_pips": cfg.ml_sl_pips,
+        "ml_forward_bars": cfg.ml_forward_bars,
+        "ml_timeframe": cfg.ml_timeframe,
+        "broker_alias": cfg.broker_alias,
+        "is_enabled": cfg.is_enabled,
+        "ml_status": cfg.ml_status,
+    }
+
+
+async def list_configs(db: AsyncSession, include_disabled: bool = True) -> list[SymbolConfig]:
+    stmt = select(SymbolConfig).where(SymbolConfig.is_deleted.is_(False))
+    if not include_disabled:
+        stmt = stmt.where(SymbolConfig.is_enabled.is_(True))
+    result = await db.execute(stmt.order_by(SymbolConfig.symbol))
+    return list(result.scalars().all())
+
+
+async def get_config(db: AsyncSession, symbol: str) -> SymbolConfig | None:
+    result = await db.execute(
+        select(SymbolConfig).where(
+            SymbolConfig.symbol == symbol,
+            SymbolConfig.is_deleted.is_(False),
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def load_profiles_from_db(db: AsyncSession) -> dict[str, dict]:
+    """Load all non-deleted configs as profile dict keyed by symbol and broker_alias."""
+    configs = await list_configs(db, include_disabled=True)
+    profiles: dict[str, dict] = {}
+    for cfg in configs:
+        profile = config_to_profile(cfg)
+        profiles[cfg.symbol] = profile
+        if cfg.broker_alias and cfg.broker_alias != cfg.symbol:
+            alias_profile = profile.copy()
+            alias_profile["canonical"] = cfg.symbol
+            profiles[cfg.broker_alias] = alias_profile
+    return profiles
+
+
+async def publish_reload(
+    redis_client: redis.Redis, symbol: str, action: str
+) -> None:
+    """Publish reload event so BotManager and scheduler refresh engines."""
+    try:
+        payload = json.dumps(
+            {
+                "symbol": symbol,
+                "action": action,
+                "ts": datetime.utcnow().isoformat(),
+            }
+        )
+        await redis_client.publish(RELOAD_CHANNEL, payload)
+    except Exception as e:
+        logger.warning(f"SymbolConfigService: publish_reload failed: {e}")

--- a/backend/tests/integration/test_api_symbols.py
+++ b/backend/tests/integration/test_api_symbols.py
@@ -1,0 +1,246 @@
+"""Integration tests for Symbol Config API."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.api.routes import symbols as symbols_routes
+from app.db.models import SymbolConfig
+from app.db.session import get_db
+
+
+def _sample_create() -> dict:
+    return {
+        "symbol": "EURUSD",
+        "display_name": "Euro/Dollar",
+        "broker_alias": "EURUSDm",
+        "default_timeframe": "M15",
+        "pip_value": 10.0,
+        "default_lot": 0.1,
+        "max_lot": 2.0,
+        "price_decimals": 5,
+        "sl_atr_mult": 1.5,
+        "tp_atr_mult": 2.0,
+        "contract_size": 100000,
+        "ml_tp_pips": 0.001,
+        "ml_sl_pips": 0.001,
+        "ml_forward_bars": 10,
+        "ml_timeframe": "M15",
+    }
+
+
+def _build_app(db_session, connector=None, redis_client=None) -> FastAPI:
+    app = FastAPI()
+    app.include_router(symbols_routes.router)
+
+    async def override_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_db
+    app.state.connector = connector
+    app.state.redis = redis_client
+    return app
+
+
+@pytest_asyncio.fixture
+async def client(db_session, redis_client):
+    connector = AsyncMock()
+    connector.get_symbol_spec.return_value = {
+        "success": True,
+        "data": {
+            "symbol": "EURUSDm",
+            "digits": 5,
+            "point": 0.00001,
+            "volume_min": 0.01,
+            "volume_max": 100.0,
+            "volume_step": 0.01,
+            "trade_contract_size": 100000.0,
+            "trade_tick_size": 0.00001,
+            "trade_tick_value": 1.0,
+            "visible": True,
+        },
+    }
+    app = _build_app(db_session, connector=connector, redis_client=redis_client)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+class TestCRUD:
+    @pytest.mark.asyncio
+    async def test_list_empty(self, client):
+        resp = await client.get("/api/symbols")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    @pytest.mark.asyncio
+    async def test_create_then_list(self, client):
+        resp = await client.post("/api/symbols", json=_sample_create())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["symbol"] == "EURUSD"
+        assert data["is_enabled"] is False
+        assert data["ml_status"] == "pending"
+
+        resp = await client.get("/api/symbols")
+        assert len(resp.json()) == 1
+
+    @pytest.mark.asyncio
+    async def test_duplicate_create_conflicts(self, client):
+        payload = _sample_create()
+        await client.post("/api/symbols", json=payload)
+        resp = await client.post("/api/symbols", json=payload)
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_update(self, client):
+        await client.post("/api/symbols", json=_sample_create())
+        updated = _sample_create()
+        del updated["symbol"]
+        updated["display_name"] = "Euro Updated"
+        updated["max_lot"] = 5.0
+        resp = await client.put("/api/symbols/EURUSD", json=updated)
+        assert resp.status_code == 200
+        assert resp.json()["display_name"] == "Euro Updated"
+        assert resp.json()["max_lot"] == 5.0
+
+    @pytest.mark.asyncio
+    async def test_toggle(self, client):
+        await client.post("/api/symbols", json=_sample_create())
+        resp = await client.post("/api/symbols/EURUSD/toggle")
+        assert resp.status_code == 200
+        assert resp.json()["is_enabled"] is True
+        resp = await client.post("/api/symbols/EURUSD/toggle")
+        assert resp.json()["is_enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_soft_delete(self, client):
+        await client.post("/api/symbols", json=_sample_create())
+        resp = await client.delete("/api/symbols/EURUSD")
+        assert resp.status_code == 200
+        resp = await client.get("/api/symbols/EURUSD")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_not_found(self, client):
+        resp = await client.get("/api/symbols/UNKNOWN")
+        assert resp.status_code == 404
+
+
+class TestValidation:
+    @pytest.mark.asyncio
+    async def test_rejects_bad_timeframe(self, client):
+        payload = _sample_create()
+        payload["default_timeframe"] = "W1"
+        resp = await client.post("/api/symbols", json=payload)
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_rejects_negative_lot(self, client):
+        payload = _sample_create()
+        payload["default_lot"] = -0.1
+        resp = await client.post("/api/symbols", json=payload)
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_rejects_default_greater_than_max(self, client):
+        payload = _sample_create()
+        payload["default_lot"] = 10.0
+        payload["max_lot"] = 1.0
+        resp = await client.post("/api/symbols", json=payload)
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_symbol_name(self, client):
+        payload = _sample_create()
+        payload["symbol"] = "EUR USD!"
+        resp = await client.post("/api/symbols", json=payload)
+        assert resp.status_code == 422
+
+
+class TestValidateBroker:
+    @pytest.mark.asyncio
+    async def test_validate_calls_mt5(self, client):
+        await client.post("/api/symbols", json=_sample_create())
+        resp = await client.post("/api/symbols/EURUSD/validate")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["spec"]["digits"] == 5
+
+
+class TestHotReload:
+    @pytest.mark.asyncio
+    async def test_toggle_publishes_redis_event(self, client, redis_client):
+        from app.services.symbol_config_service import RELOAD_CHANNEL
+
+        pubsub = redis_client.pubsub()
+        await pubsub.subscribe(RELOAD_CHANNEL)
+        # consume the subscribe confirmation
+        await pubsub.get_message(timeout=0.1)
+
+        await client.post("/api/symbols", json=_sample_create())
+
+        # Drain any pending messages and confirm at least one reload event emitted
+        seen = []
+        for _ in range(5):
+            msg = await pubsub.get_message(timeout=0.2)
+            if msg and msg.get("type") == "message":
+                seen.append(msg)
+        assert seen, "expected a reload event on Redis channel"
+        await pubsub.unsubscribe(RELOAD_CHANNEL)
+        await pubsub.aclose()
+
+
+class TestFallback:
+    @pytest.mark.asyncio
+    async def test_db_empty_uses_static_profiles(self, db_session):
+        from app.config import SYMBOL_PROFILES, apply_db_symbol_profiles
+        from app.services.symbol_config_service import load_profiles_from_db
+
+        profiles = await load_profiles_from_db(db_session)
+        assert profiles == {}
+        # Static fallback retained
+        assert "GOLD" in SYMBOL_PROFILES
+        apply_db_symbol_profiles({})
+        assert "GOLD" in SYMBOL_PROFILES
+
+
+class TestProfileMerge:
+    @pytest.mark.asyncio
+    async def test_db_profile_overrides_static(self, db_session):
+        from app.config import SYMBOL_PROFILES, apply_db_symbol_profiles
+        from app.services.symbol_config_service import load_profiles_from_db
+
+        cfg = SymbolConfig(
+            symbol="GOLD",
+            display_name="Gold Override",
+            broker_alias="GOLDx",
+            is_enabled=True,
+            default_timeframe="M15",
+            pip_value=1.0,
+            default_lot=0.05,
+            max_lot=0.5,
+            price_decimals=2,
+            sl_atr_mult=1.5,
+            tp_atr_mult=2.0,
+            contract_size=100,
+            ml_tp_pips=10.0,
+            ml_sl_pips=10.0,
+            ml_forward_bars=10,
+            ml_timeframe="M15",
+        )
+        db_session.add(cfg)
+        await db_session.commit()
+
+        db_profiles = await load_profiles_from_db(db_session)
+        apply_db_symbol_profiles(db_profiles)
+        assert SYMBOL_PROFILES["GOLD"]["display_name"] == "Gold Override"
+        assert SYMBOL_PROFILES["GOLD"]["default_lot"] == 0.05
+        assert SYMBOL_PROFILES["GOLDx"]["canonical"] == "GOLD"
+
+        # Restore static profiles so later tests are not polluted
+        apply_db_symbol_profiles({})

--- a/backend/tests/integration/test_api_symbols.py
+++ b/backend/tests/integration/test_api_symbols.py
@@ -161,6 +161,53 @@ class TestValidation:
         assert resp.status_code == 422
 
 
+class TestRetrain:
+    @pytest.mark.asyncio
+    async def test_retrain_requires_manager(self, client):
+        await client.post("/api/symbols", json=_sample_create())
+        resp = await client.post("/api/symbols/EURUSD/retrain")
+        assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_retrain_queues_task_and_sets_training(self, db_session, redis_client):
+        from unittest.mock import AsyncMock, MagicMock
+        connector = AsyncMock()
+
+        retrain_started = False
+
+        async def fake_retrain(symbol, engine):
+            nonlocal retrain_started
+            retrain_started = True
+
+        scheduler = MagicMock()
+        scheduler._ml_retrain_symbol = fake_retrain
+        manager = MagicMock()
+        engine_mock = MagicMock()
+        manager.get_engine.return_value = engine_mock
+
+        app = _build_app(db_session, connector=connector, redis_client=redis_client)
+        app.state.scheduler = scheduler
+        app.state.manager = manager
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            await c.post("/api/symbols", json=_sample_create())
+            resp = await c.post("/api/symbols/EURUSD/retrain")
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "training"
+
+            resp2 = await c.get("/api/symbols/EURUSD")
+            assert resp2.json()["ml_status"] == "training"
+
+            # Retrain already running: second call should 409
+            resp3 = await c.post("/api/symbols/EURUSD/retrain")
+            assert resp3.status_code == 409
+
+        # Give the background task a moment to run
+        import asyncio
+        await asyncio.sleep(0.05)
+        assert retrain_started is True
+
+
 class TestValidateBroker:
     @pytest.mark.asyncio
     async def test_validate_calls_mt5(self, client):

--- a/backend/tests/unit/test_strategy_switch_guard.py
+++ b/backend/tests/unit/test_strategy_switch_guard.py
@@ -40,8 +40,14 @@ class TestFeatureFlag:
 
 
 # ─── Validate switch ────────────────────────────────────────────────────────
-# Note: is_market_open check is skipped in tests because app.bot.scheduler
-# cannot be imported without full app context. The guard catches ImportError.
+
+
+@pytest.fixture(autouse=True)
+def _force_market_open(monkeypatch):
+    """Bypass weekend/daily-close gate so validate_switch tests are time-independent."""
+    import app.bot.scheduler as sched
+
+    monkeypatch.setattr(sched, "is_market_open", lambda _symbol: True)
 
 
 class TestValidateSwitch:

--- a/frontend/app/symbols/SymbolForm.tsx
+++ b/frontend/app/symbols/SymbolForm.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { SymbolConfig, SymbolConfigInput } from "@/lib/api";
+
+const TIMEFRAMES = ["M1", "M5", "M15", "M30", "H1", "H4", "D1"] as const;
+
+interface SymbolFormProps {
+  initial?: SymbolConfig;
+  onSubmit: (input: SymbolConfigInput) => Promise<void>;
+  onCancel: () => void;
+  onValidateAlias?: (alias: string) => Promise<void>;
+  submitting?: boolean;
+}
+
+type FormState = {
+  symbol: string;
+  display_name: string;
+  broker_alias: string;
+  default_timeframe: string;
+  pip_value: string;
+  default_lot: string;
+  max_lot: string;
+  price_decimals: string;
+  sl_atr_mult: string;
+  tp_atr_mult: string;
+  contract_size: string;
+  ml_tp_pips: string;
+  ml_sl_pips: string;
+  ml_forward_bars: string;
+  ml_timeframe: string;
+};
+
+function toFormState(cfg?: SymbolConfig): FormState {
+  return {
+    symbol: cfg?.symbol ?? "",
+    display_name: cfg?.display_name ?? "",
+    broker_alias: cfg?.broker_alias ?? "",
+    default_timeframe: cfg?.default_timeframe ?? "M15",
+    pip_value: String(cfg?.pip_value ?? ""),
+    default_lot: String(cfg?.default_lot ?? ""),
+    max_lot: String(cfg?.max_lot ?? ""),
+    price_decimals: String(cfg?.price_decimals ?? 2),
+    sl_atr_mult: String(cfg?.sl_atr_mult ?? 1.5),
+    tp_atr_mult: String(cfg?.tp_atr_mult ?? 2.0),
+    contract_size: String(cfg?.contract_size ?? 1),
+    ml_tp_pips: String(cfg?.ml_tp_pips ?? ""),
+    ml_sl_pips: String(cfg?.ml_sl_pips ?? ""),
+    ml_forward_bars: String(cfg?.ml_forward_bars ?? 10),
+    ml_timeframe: cfg?.ml_timeframe ?? "M15",
+  };
+}
+
+function toPayload(state: FormState): SymbolConfigInput {
+  return {
+    symbol: state.symbol.trim(),
+    display_name: state.display_name.trim(),
+    broker_alias: state.broker_alias.trim() || null,
+    default_timeframe: state.default_timeframe,
+    pip_value: Number(state.pip_value),
+    default_lot: Number(state.default_lot),
+    max_lot: Number(state.max_lot),
+    price_decimals: Number(state.price_decimals),
+    sl_atr_mult: Number(state.sl_atr_mult),
+    tp_atr_mult: Number(state.tp_atr_mult),
+    contract_size: Number(state.contract_size),
+    ml_tp_pips: Number(state.ml_tp_pips),
+    ml_sl_pips: Number(state.ml_sl_pips),
+    ml_forward_bars: Number(state.ml_forward_bars),
+    ml_timeframe: state.ml_timeframe,
+  };
+}
+
+function validate(state: FormState): string | null {
+  if (!state.symbol.match(/^[A-Za-z0-9._-]{2,32}$/)) return "Symbol must be 2-32 alphanumeric chars";
+  if (!state.display_name) return "Display name required";
+  const nums = [
+    ["pip_value", state.pip_value],
+    ["default_lot", state.default_lot],
+    ["max_lot", state.max_lot],
+    ["contract_size", state.contract_size],
+    ["ml_tp_pips", state.ml_tp_pips],
+    ["ml_sl_pips", state.ml_sl_pips],
+  ] as const;
+  for (const [field, raw] of nums) {
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n <= 0) return `${field} must be > 0`;
+  }
+  if (Number(state.default_lot) > Number(state.max_lot)) {
+    return "default_lot must be <= max_lot";
+  }
+  return null;
+}
+
+export function SymbolForm({
+  initial,
+  onSubmit,
+  onCancel,
+  onValidateAlias,
+  submitting,
+}: SymbolFormProps) {
+  const [state, setState] = useState<FormState>(toFormState(initial));
+  const [error, setError] = useState<string | null>(null);
+
+  const isEdit = Boolean(initial);
+
+  const update = <K extends keyof FormState>(key: K, value: FormState[K]) =>
+    setState((prev) => ({ ...prev, [key]: value }));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const err = validate(state);
+    if (err) {
+      setError(err);
+      return;
+    }
+    setError(null);
+    await onSubmit(toPayload(state));
+  };
+
+  const handleValidate = async () => {
+    if (!onValidateAlias) return;
+    const alias = state.broker_alias.trim() || state.symbol.trim();
+    if (!alias) {
+      setError("Enter a symbol or broker alias first");
+      return;
+    }
+    await onValidateAlias(alias);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <Field label="Symbol (canonical)" required>
+          <Input
+            value={state.symbol}
+            onChange={(e) => update("symbol", e.target.value)}
+            disabled={isEdit}
+            placeholder="EURUSD"
+          />
+        </Field>
+        <Field label="Display name" required>
+          <Input
+            value={state.display_name}
+            onChange={(e) => update("display_name", e.target.value)}
+            placeholder="Euro/Dollar"
+          />
+        </Field>
+        <Field label="Broker alias (e.g. EURUSDmicro)">
+          <div className="flex gap-2">
+            <Input
+              value={state.broker_alias}
+              onChange={(e) => update("broker_alias", e.target.value)}
+              placeholder="optional"
+            />
+            {onValidateAlias && (
+              <Button type="button" variant="outline" size="sm" onClick={handleValidate}>
+                Validate
+              </Button>
+            )}
+          </div>
+        </Field>
+        <Field label="Default timeframe">
+          <Select
+            value={state.default_timeframe}
+            onValueChange={(v) => update("default_timeframe", v as string)}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TIMEFRAMES.map((tf) => (
+                <SelectItem key={tf} value={tf}>
+                  {tf}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field label="Pip value" required>
+          <Input
+            type="number"
+            step="any"
+            value={state.pip_value}
+            onChange={(e) => update("pip_value", e.target.value)}
+          />
+        </Field>
+        <Field label="Price decimals">
+          <Input
+            type="number"
+            value={state.price_decimals}
+            onChange={(e) => update("price_decimals", e.target.value)}
+          />
+        </Field>
+        <Field label="Default lot" required>
+          <Input
+            type="number"
+            step="any"
+            value={state.default_lot}
+            onChange={(e) => update("default_lot", e.target.value)}
+          />
+        </Field>
+        <Field label="Max lot" required>
+          <Input
+            type="number"
+            step="any"
+            value={state.max_lot}
+            onChange={(e) => update("max_lot", e.target.value)}
+          />
+        </Field>
+        <Field label="SL ATR multiplier">
+          <Input
+            type="number"
+            step="any"
+            value={state.sl_atr_mult}
+            onChange={(e) => update("sl_atr_mult", e.target.value)}
+          />
+        </Field>
+        <Field label="TP ATR multiplier">
+          <Input
+            type="number"
+            step="any"
+            value={state.tp_atr_mult}
+            onChange={(e) => update("tp_atr_mult", e.target.value)}
+          />
+        </Field>
+        <Field label="Contract size" required>
+          <Input
+            type="number"
+            step="any"
+            value={state.contract_size}
+            onChange={(e) => update("contract_size", e.target.value)}
+          />
+        </Field>
+        <Field label="ML timeframe">
+          <Select
+            value={state.ml_timeframe}
+            onValueChange={(v) => update("ml_timeframe", v as string)}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TIMEFRAMES.map((tf) => (
+                <SelectItem key={tf} value={tf}>
+                  {tf}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field label="ML TP pips" required>
+          <Input
+            type="number"
+            step="any"
+            value={state.ml_tp_pips}
+            onChange={(e) => update("ml_tp_pips", e.target.value)}
+          />
+        </Field>
+        <Field label="ML SL pips" required>
+          <Input
+            type="number"
+            step="any"
+            value={state.ml_sl_pips}
+            onChange={(e) => update("ml_sl_pips", e.target.value)}
+          />
+        </Field>
+        <Field label="ML forward bars">
+          <Input
+            type="number"
+            value={state.ml_forward_bars}
+            onChange={(e) => update("ml_forward_bars", e.target.value)}
+          />
+        </Field>
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="outline" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={submitting}>
+          {submitting ? "Saving..." : isEdit ? "Save changes" : "Create symbol"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function Field({
+  label,
+  required,
+  children,
+}: {
+  label: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="text-xs font-medium text-muted-foreground">
+        {label}
+        {required && <span className="text-destructive"> *</span>}
+      </span>
+      {children}
+    </label>
+  );
+}

--- a/frontend/app/symbols/page.tsx
+++ b/frontend/app/symbols/page.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AxiosError } from "axios";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  createSymbolConfig,
+  deleteSymbolConfig,
+  listSymbolConfigs,
+  retrainSymbolConfig,
+  toggleSymbolConfig,
+  updateSymbolConfig,
+  validateSymbolConfig,
+  type SymbolConfig,
+  type SymbolConfigInput,
+} from "@/lib/api";
+import { SymbolForm } from "./SymbolForm";
+
+function errorMessage(err: unknown): string {
+  if (err instanceof AxiosError) {
+    const detail = err.response?.data?.detail;
+    if (typeof detail === "string") return detail;
+    if (Array.isArray(detail) && detail.length) return detail[0].msg ?? "Validation error";
+    return err.message;
+  }
+  if (err instanceof Error) return err.message;
+  return "Unexpected error";
+}
+
+export default function SymbolsPage() {
+  const [configs, setConfigs] = useState<SymbolConfig[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<SymbolConfig | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [banner, setBanner] = useState<{ kind: "ok" | "err"; msg: string } | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const resp = await listSymbolConfigs();
+        if (active) setConfigs(resp.data);
+      } catch (err) {
+        if (active) setBanner({ kind: "err", msg: errorMessage(err) });
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const upsertLocal = (cfg: SymbolConfig) =>
+    setConfigs((prev) => {
+      const i = prev.findIndex((c) => c.symbol === cfg.symbol);
+      if (i === -1) return [...prev, cfg];
+      const next = prev.slice();
+      next[i] = cfg;
+      return next;
+    });
+
+  const removeLocal = (symbol: string) =>
+    setConfigs((prev) => prev.filter((c) => c.symbol !== symbol));
+
+  const openCreate = () => {
+    setEditing(null);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (cfg: SymbolConfig) => {
+    setEditing(cfg);
+    setDialogOpen(true);
+  };
+
+  const handleSubmit = async (input: SymbolConfigInput) => {
+    setSubmitting(true);
+    try {
+      if (editing) {
+        const { symbol: _omit, ...rest } = input;
+        void _omit;
+        const resp = await updateSymbolConfig(editing.symbol, rest);
+        upsertLocal(resp.data);
+        setBanner({ kind: "ok", msg: `Updated ${editing.symbol}` });
+      } else {
+        const resp = await createSymbolConfig(input);
+        upsertLocal(resp.data);
+        setBanner({ kind: "ok", msg: `Created ${input.symbol}` });
+      }
+      setDialogOpen(false);
+    } catch (err) {
+      setBanner({ kind: "err", msg: errorMessage(err) });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleToggle = async (cfg: SymbolConfig) => {
+    try {
+      const resp = await toggleSymbolConfig(cfg.symbol);
+      upsertLocal(resp.data);
+    } catch (err) {
+      setBanner({ kind: "err", msg: errorMessage(err) });
+    }
+  };
+
+  const handleDelete = async (cfg: SymbolConfig) => {
+    if (!confirm(`Delete ${cfg.symbol}? This disables the symbol and removes it from the active list.`)) {
+      return;
+    }
+    try {
+      await deleteSymbolConfig(cfg.symbol);
+      removeLocal(cfg.symbol);
+      setBanner({ kind: "ok", msg: `Deleted ${cfg.symbol}` });
+    } catch (err) {
+      setBanner({ kind: "err", msg: errorMessage(err) });
+    }
+  };
+
+  const handleRetrain = async (cfg: SymbolConfig) => {
+    try {
+      await retrainSymbolConfig(cfg.symbol);
+      upsertLocal({ ...cfg, ml_status: "training" });
+      setBanner({ kind: "ok", msg: `Queued retrain for ${cfg.symbol}` });
+    } catch (err) {
+      setBanner({ kind: "err", msg: errorMessage(err) });
+    }
+  };
+
+  const handleValidate = async (cfg: SymbolConfig) => {
+    try {
+      const resp = await validateSymbolConfig(cfg.symbol);
+      if (resp.data.ok) {
+        setBanner({
+          kind: "ok",
+          msg: `${cfg.symbol}: broker spec OK (digits ${resp.data.spec?.digits}, min lot ${resp.data.spec?.volume_min})`,
+        });
+      } else {
+        setBanner({ kind: "err", msg: `${cfg.symbol}: ${resp.data.message}` });
+      }
+    } catch (err) {
+      setBanner({ kind: "err", msg: errorMessage(err) });
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        title="Symbols"
+        subtitle="Manage tradable instruments, profiles, and broker aliases"
+      >
+        <Button onClick={openCreate}>Add Symbol</Button>
+      </PageHeader>
+
+      {banner && (
+        <div
+          className={
+            banner.kind === "ok"
+              ? "rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-600"
+              : "rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          }
+        >
+          {banner.msg}
+        </div>
+      )}
+
+      <div className="rounded-xl border bg-card">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Symbol</TableHead>
+              <TableHead>Display</TableHead>
+              <TableHead>Broker alias</TableHead>
+              <TableHead>TF</TableHead>
+              <TableHead>Lot (def / max)</TableHead>
+              <TableHead>SL/TP ATR</TableHead>
+              <TableHead>ML</TableHead>
+              <TableHead>Enabled</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={9}>
+                  <Skeleton className="h-24 w-full" />
+                </TableCell>
+              </TableRow>
+            ) : configs.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={9} className="text-center text-muted-foreground py-8">
+                  No symbols configured. Click &quot;Add Symbol&quot; to create one.
+                </TableCell>
+              </TableRow>
+            ) : (
+              configs.map((cfg) => (
+                <TableRow key={cfg.symbol}>
+                  <TableCell className="font-mono font-semibold">{cfg.symbol}</TableCell>
+                  <TableCell>{cfg.display_name}</TableCell>
+                  <TableCell className="font-mono text-xs text-muted-foreground">
+                    {cfg.broker_alias ?? "—"}
+                  </TableCell>
+                  <TableCell>{cfg.default_timeframe}</TableCell>
+                  <TableCell>
+                    {cfg.default_lot} / {cfg.max_lot}
+                  </TableCell>
+                  <TableCell>
+                    {cfg.sl_atr_mult} / {cfg.tp_atr_mult}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={cfg.ml_status === "ready" ? "default" : "outline"}>
+                      {cfg.ml_status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Switch
+                      checked={cfg.is_enabled}
+                      onCheckedChange={() => void handleToggle(cfg)}
+                    />
+                  </TableCell>
+                  <TableCell className="text-right space-x-1">
+                    <Button variant="ghost" size="sm" onClick={() => void handleValidate(cfg)}>
+                      Validate
+                    </Button>
+                    <Button variant="ghost" size="sm" onClick={() => void handleRetrain(cfg)}>
+                      Retrain
+                    </Button>
+                    <Button variant="ghost" size="sm" onClick={() => openEdit(cfg)}>
+                      Edit
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-destructive"
+                      onClick={() => void handleDelete(cfg)}
+                    >
+                      Delete
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{editing ? `Edit ${editing.symbol}` : "Add symbol"}</DialogTitle>
+            <DialogDescription>
+              {editing
+                ? "Update trading profile. Changes apply immediately via hot-reload."
+                : "Create a new symbol profile. Validate the broker alias before enabling."}
+            </DialogDescription>
+          </DialogHeader>
+          <SymbolForm
+            key={editing?.symbol ?? "new"}
+            initial={editing ?? undefined}
+            onSubmit={handleSubmit}
+            onCancel={() => setDialogOpen(false)}
+            submitting={submitting}
+          />
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -25,6 +25,7 @@ import {
   Shield,
   Zap,
   Database,
+  CandlestickChart,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
@@ -45,6 +46,7 @@ const navGroups: NavGroup[] = [
   {
     label: "Trading",
     items: [
+      { href: "/symbols", label: "Symbols", icon: CandlestickChart },
       { href: "/backtest", label: "Backtest", icon: BarChart3 },
       { href: "/history", label: "History", icon: History },
     ],

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -243,6 +243,70 @@ export const archiveTrades = (before: string) => api.post("/api/admin/trades/arc
 export const unarchiveTrades = (before: string) => api.post("/api/admin/trades/unarchive", null, { params: { before } });
 export const getArchiveCount = () => api.get("/api/admin/trades/archive-count");
 
+// Symbol Config
+export interface SymbolConfig {
+  symbol: string;
+  display_name: string;
+  broker_alias: string | null;
+  is_enabled: boolean;
+  default_timeframe: string;
+  pip_value: number;
+  default_lot: number;
+  max_lot: number;
+  price_decimals: number;
+  sl_atr_mult: number;
+  tp_atr_mult: number;
+  contract_size: number;
+  ml_tp_pips: number;
+  ml_sl_pips: number;
+  ml_forward_bars: number;
+  ml_timeframe: string;
+  ml_status: string;
+  ml_last_trained_at: string | null;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export type SymbolConfigInput = Omit<
+  SymbolConfig,
+  "is_enabled" | "ml_status" | "ml_last_trained_at" | "created_at" | "updated_at"
+>;
+
+export interface SymbolSpec {
+  symbol: string;
+  digits: number;
+  point: number;
+  volume_min: number;
+  volume_max: number;
+  volume_step: number;
+  trade_contract_size: number;
+  trade_tick_size: number;
+  trade_tick_value: number;
+  visible: boolean;
+}
+
+export const listSymbolConfigs = () => api.get<SymbolConfig[]>("/api/symbols");
+export const getSymbolConfig = (symbol: string) =>
+  api.get<SymbolConfig>(`/api/symbols/${symbol}`);
+export const createSymbolConfig = (input: SymbolConfigInput) =>
+  api.post<SymbolConfig>("/api/symbols", input);
+export const updateSymbolConfig = (symbol: string, input: Omit<SymbolConfigInput, "symbol">) =>
+  api.put<SymbolConfig>(`/api/symbols/${symbol}`, input);
+export const deleteSymbolConfig = (symbol: string) =>
+  api.delete<{ status: string; symbol: string }>(`/api/symbols/${symbol}`);
+export const toggleSymbolConfig = (symbol: string) =>
+  api.post<SymbolConfig>(`/api/symbols/${symbol}/toggle`);
+export const validateSymbolConfig = (symbol: string) =>
+  api.post<{ ok: boolean; message: string; spec: SymbolSpec | null }>(
+    `/api/symbols/${symbol}/validate`,
+  );
+export const retrainSymbolConfig = (symbol: string) =>
+  api.post<{ status: string; symbol: string }>(`/api/symbols/${symbol}/retrain`);
+export const getSymbolMlStatus = (symbol: string) =>
+  api.get<{ symbol: string; status: string; last_trained_at: string | null }>(
+    `/api/symbols/${symbol}/ml-status`,
+  );
+
 // AI usage monitoring
 export const getAIUsageSummary = (days: number) =>
   api.get("/api/ai-usage/summary", { params: { days } });

--- a/mt5_bridge/main.py
+++ b/mt5_bridge/main.py
@@ -136,6 +136,31 @@ async def get_tick(symbol: str):
     })
 
 
+@app.get("/symbol-spec/{symbol}", dependencies=[Depends(verify_api_key)])
+async def get_symbol_spec(symbol: str):
+    """Return broker-side spec for a symbol (used by Symbol Config UI to validate + auto-fill)."""
+    if not ensure_connected():
+        return mt5_response(False, error="MT5 not connected")
+    info = mt5.symbol_info(symbol)
+    if info is None:
+        return mt5_response(False, error=f"Symbol {symbol} not found")
+    if not info.visible:
+        mt5.symbol_select(symbol, True)
+        info = mt5.symbol_info(symbol)
+    return mt5_response(True, data={
+        "symbol": info.name,
+        "digits": int(info.digits),
+        "point": float(info.point),
+        "volume_min": float(info.volume_min),
+        "volume_max": float(info.volume_max),
+        "volume_step": float(info.volume_step),
+        "trade_contract_size": float(info.trade_contract_size),
+        "trade_tick_size": float(info.trade_tick_size),
+        "trade_tick_value": float(info.trade_tick_value),
+        "visible": bool(info.visible),
+    })
+
+
 @app.get("/ohlcv/{symbol}", dependencies=[Depends(verify_api_key)])
 async def get_ohlcv(symbol: str, timeframe: str = "M15", count: int = 100):
     if not ensure_connected():

--- a/mt5_bridge/main.py
+++ b/mt5_bridge/main.py
@@ -147,6 +147,8 @@ async def get_symbol_spec(symbol: str):
     if not info.visible:
         mt5.symbol_select(symbol, True)
         info = mt5.symbol_info(symbol)
+        if info is None:
+            return mt5_response(False, error=f"Symbol {symbol} not available after select")
     return mt5_response(True, data={
         "symbol": info.name,
         "digits": int(info.digits),


### PR DESCRIPTION
## Summary
- Add DB-backed `symbol_configs` table (seeded from static `SYMBOL_PROFILES`) so symbols + profiles can be managed from the web instead of redeploying.
- Ship `/symbols` page with CRUD, enable/disable toggle, broker-alias validation via MT5 Bridge, and on-demand ML retrain.
- Hot-reload `BotManager.engines` through a Redis `symbol_config_changed` pub/sub channel — no restart required.

## Key changes
- `backend/app/db/models.py` + Alembic migration `q7r8s9t0u1v2` (seeds GOLD/OILCash/BTCUSD/USDJPY).
- `backend/app/api/routes/symbols.py` — 9 endpoints behind `require_auth`.
- `backend/app/services/symbol_config_service.py` — DB loader + Redis publisher.
- `backend/app/bot/manager.py` — `reload_engines`, debounced subscriber, exponential backoff, parallel engine stops.
- `backend/app/bot/engine.py` — `apply_profile()` hot-reload entry.
- `backend/app/config.py` — `apply_db_symbol_profiles` merges DB rows over static defaults.
- `mt5_bridge/main.py` + `backend/app/mt5/connector.py` — new `/symbol-spec/{symbol}` endpoint.
- Frontend: `lib/api.ts` types + fns, `/symbols` page + form, sidebar link.

## Test plan
- [ ] `alembic upgrade head` — confirm `symbol_configs` exists with 4 seed rows
- [ ] `.venv/Scripts/python.exe -m pytest tests/integration/test_api_symbols.py -v --no-cov`
- [ ] `npx tsc --noEmit` (passes locally)
- [ ] `npm run build`
- [ ] Smoke: add a new symbol (e.g. EURUSD) → validate broker alias → toggle enabled → confirm `BotManager: created engine EURUSD` in logs
- [ ] Disable existing symbol → engine stops, candle job no longer fires for it
- [ ] Retrain a symbol → `ml_status` transitions pending → training → ready
- [ ] MT5 Bridge deployed on Windows VPS with new `/symbol-spec` endpoint

## Notes
- Static `SYMBOL_PROFILES` kept as fallback: if DB is empty or unavailable, behavior matches current main.
- Migration is additive / non-destructive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)