### PR TITLE
security: batch fixes from code review (#14-28)

### DIFF
--- a/backend/app/auth_webauthn.py
+++ b/backend/app/auth_webauthn.py
@@ -19,8 +19,40 @@ from app.db.session import get_db
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
-# In-memory challenge store (short-lived, per-request)
-_challenges: dict[str, bytes] = {}
+# Challenge store — prefers Redis (multi-instance safe, 5 min TTL); falls back to
+# process-local dict when Redis is unreachable (single-instance dev).
+_CHALLENGE_TTL_SECONDS = 300
+_local_challenges: dict[str, bytes] = {}
+
+
+def _redis(request: Request | None):
+    if request is None:
+        return None
+    return getattr(request.app.state, "redis", None)
+
+
+async def _store_challenge(request: Request | None, key: str, value: bytes) -> None:
+    client = _redis(request)
+    if client is not None:
+        try:
+            await client.set(f"webauthn:challenge:{key}", value, ex=_CHALLENGE_TTL_SECONDS)
+            return
+        except Exception as e:
+            logger.warning(f"WebAuthn Redis store failed, using memory: {e}")
+    _local_challenges[key] = value
+
+
+async def _pop_challenge(request: Request | None, key: str) -> bytes | None:
+    client = _redis(request)
+    if client is not None:
+        try:
+            raw = await client.get(f"webauthn:challenge:{key}")
+            if raw is not None:
+                await client.delete(f"webauthn:challenge:{key}")
+                return raw if isinstance(raw, bytes) else raw.encode()
+        except Exception as e:
+            logger.warning(f"WebAuthn Redis read failed, using memory: {e}")
+    return _local_challenges.pop(key, None)
 
 RP_ID = settings.webauthn_rp_id if hasattr(settings, "webauthn_rp_id") else "localhost"
 RP_NAME = "AI Trading Agent"
@@ -71,7 +103,7 @@ class RegisterOptionsRequest(BaseModel):
 
 
 @router.post("/register/options")
-async def register_options(req: RegisterOptionsRequest, db: AsyncSession = Depends(get_db)):
+async def register_options(req: RegisterOptionsRequest, request: Request, db: AsyncSession = Depends(get_db)):
     """Generate WebAuthn registration challenge. Only works if setup not complete."""
     from webauthn import generate_registration_options
     from webauthn.helpers.structs import AuthenticatorSelectionCriteria, ResidentKeyRequirement
@@ -111,8 +143,7 @@ async def register_options(req: RegisterOptionsRequest, db: AsyncSession = Depen
         ],
     )
 
-    # Store challenge for verification
-    _challenges[str(owner.id)] = options.challenge
+    await _store_challenge(request, str(owner.id), options.challenge)
 
     from webauthn.helpers import options_to_json
     return {"options": options_to_json(options), "owner_id": owner.id}
@@ -125,13 +156,13 @@ class RegisterVerifyRequest(BaseModel):
 
 
 @router.post("/register/verify")
-async def register_verify(req: RegisterVerifyRequest, db: AsyncSession = Depends(get_db)):
+async def register_verify(req: RegisterVerifyRequest, request: Request, db: AsyncSession = Depends(get_db)):
     """Verify registration response and store credential."""
     from webauthn import verify_registration_response
     from webauthn.helpers import parse_registration_credential_json
     import json
 
-    challenge = _challenges.pop(str(req.owner_id), None)
+    challenge = await _pop_challenge(request, str(req.owner_id))
     if not challenge:
         raise HTTPException(status_code=400, detail="Registration challenge expired")
 
@@ -175,7 +206,7 @@ async def register_verify(req: RegisterVerifyRequest, db: AsyncSession = Depends
 # ─── Login ────────────────────────────────────────────────────────────────────
 
 @router.post("/login/options")
-async def login_options(db: AsyncSession = Depends(get_db)):
+async def login_options(request: Request, db: AsyncSession = Depends(get_db)):
     """Generate WebAuthn login challenge."""
     from webauthn import generate_authentication_options
 
@@ -199,7 +230,7 @@ async def login_options(db: AsyncSession = Depends(get_db)):
         ],
     )
 
-    _challenges["login"] = options.challenge
+    await _store_challenge(request, "login", options.challenge)
 
     from webauthn.helpers import options_to_json
     return {"options": options_to_json(options)}
@@ -217,7 +248,7 @@ async def login_verify(req: LoginVerifyRequest, request: Request, response: Resp
     from webauthn.helpers import parse_authentication_credential_json
     import json
 
-    challenge = _challenges.pop("login", None)
+    challenge = await _pop_challenge(request, "login")
     if not challenge:
         raise HTTPException(status_code=400, detail="Login challenge expired")
 

--- a/backend/app/bot/engine.py
+++ b/backend/app/bot/engine.py
@@ -2,6 +2,7 @@
 Bot Engine — main trading loop integrating strategy, risk, AI sentiment, and orders.
 """
 
+import asyncio
 import enum
 import json
 import random
@@ -78,6 +79,26 @@ from app.mt5.connector import MT5BridgeConnector
 from app.mt5.market_data import MarketDataService
 from app.mt5.order_executor import OrderExecutor
 from app.news.fetcher import NewsFetcher
+
+
+_BACKGROUND_TASKS: set[asyncio.Task] = set()
+
+
+def _spawn_background(coro, *, name: str | None = None) -> asyncio.Task:
+    """Fire-and-forget with exception logging + hard reference (prevents GC)."""
+    task = asyncio.create_task(coro, name=name)
+    _BACKGROUND_TASKS.add(task)
+
+    def _done(t: asyncio.Task) -> None:
+        _BACKGROUND_TASKS.discard(t)
+        if t.cancelled():
+            return
+        exc = t.exception()
+        if exc is not None:
+            logger.error(f"background task {t.get_name()} raised: {exc!r}")
+
+    task.add_done_callback(_done)
+    return task
 from app.risk.circuit_breaker import CircuitBreaker
 from app.risk.manager import RiskManager
 from app.strategy import get_strategy
@@ -748,11 +769,13 @@ class BotEngine:
         latency_ms = int((time.monotonic() - start_time) * 1000)
 
         # Audit log (truly fire-and-forget — don't block order path)
-        import asyncio as _asyncio
-        _asyncio.create_task(self._log_order_audit(
-            order_type, lot, sl_tp.sl, sl_tp.tp, entry_price, result,
-            self.strategy.name, latency_ms,
-        ))
+        _spawn_background(
+            self._log_order_audit(
+                order_type, lot, sl_tp.sl, sl_tp.tp, entry_price, result,
+                self.strategy.name, latency_ms,
+            ),
+            name=f"order_audit_{self.symbol}",
+        )
 
         if not result.get("success"):
             error_msg = result.get("error", "Unknown error")
@@ -868,8 +891,10 @@ class BotEngine:
                 from app.constants import LOSING_STREAK_ALERT_THRESHOLD
                 if consecutive_losses >= LOSING_STREAK_ALERT_THRESHOLD and self.notifier:
                     factor = STREAK_3_FACTOR if consecutive_losses >= 3 else STREAK_2_FACTOR
-                    import asyncio as _asyncio
-                    _asyncio.create_task(self.notifier.send_losing_streak_alert(self.symbol, consecutive_losses, factor))
+                    _spawn_background(
+                        self.notifier.send_losing_streak_alert(self.symbol, consecutive_losses, factor),
+                        name=f"loss_streak_alert_{self.symbol}",
+                    )
         except Exception:
             pass
         return lot

--- a/backend/app/bot/manager.py
+++ b/backend/app/bot/manager.py
@@ -32,6 +32,7 @@ class BotManager:
         self.engines: dict[str, BotEngine] = {}
         self._positions_cache: dict[str, list[dict]] = {}
         self._positions_cache_time: float = 0
+        self._positions_lock = asyncio.Lock()
         self._reload_task: asyncio.Task | None = None
         self._sentiment_analyzer = None
         self._notifier = None
@@ -119,21 +120,25 @@ class BotManager:
         }
 
     async def get_active_positions(self) -> dict[str, list[dict]]:
-        """Get open positions grouped by symbol (cached 30s)."""
+        """Get open positions grouped by symbol (cached 30s). Lock guards concurrent misses."""
         now = time.time()
         if now - self._positions_cache_time < 30 and self._positions_cache:
             return self._positions_cache
-        result = {}
-        for symbol, engine in self.engines.items():
-            try:
-                positions = await engine.executor.get_open_positions(symbol)
-                if positions:
-                    result[symbol] = positions
-            except Exception:
-                pass
-        self._positions_cache = result
-        self._positions_cache_time = now
-        return result
+        async with self._positions_lock:
+            now = time.time()
+            if now - self._positions_cache_time < 30 and self._positions_cache:
+                return self._positions_cache
+            result: dict[str, list[dict]] = {}
+            for symbol, engine in self.engines.items():
+                try:
+                    positions = await engine.executor.get_open_positions(symbol)
+                    if positions:
+                        result[symbol] = positions
+                except Exception:
+                    pass
+            self._positions_cache = result
+            self._positions_cache_time = now
+            return result
 
     async def get_portfolio_exposure(self, balance: float) -> dict:
         """Calculate total notional exposure across all symbols."""

--- a/backend/app/middleware/rate_limit.py
+++ b/backend/app/middleware/rate_limit.py
@@ -76,6 +76,17 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     Exempt paths: WebSocket upgrades, /health*, /api/metrics, static assets.
     """
 
+    # Auth endpoints get a tighter bucket to blunt brute-force / credential stuffing.
+    AUTH_PATHS: tuple[str, ...] = (
+        "/api/auth/login",
+        "/api/auth/login/options",
+        "/api/auth/login/verify",
+        "/api/auth/register/options",
+        "/api/auth/register/verify",
+    )
+    AUTH_PER_MINUTE = 5
+    AUTH_BURST = 10
+
     def __init__(
         self,
         app,
@@ -87,6 +98,8 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self.refill_rate = sustained_per_minute / 60.0  # tokens per second
         self.capacity = burst_capacity if burst_capacity is not None else sustained_per_minute * 2
         self.exempt_prefixes = exempt_prefixes
+        self.auth_refill = self.AUTH_PER_MINUTE / 60.0
+        self.auth_capacity = self.AUTH_BURST
 
     def _client_ip(self, request: Request) -> str:
         # Railway/Vercel put real IP in X-Forwarded-For
@@ -105,6 +118,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         ip = self._client_ip(request)
+        is_auth_path = path in self.AUTH_PATHS
+        capacity = self.auth_capacity if is_auth_path else self.capacity
+        refill = self.auth_refill if is_auth_path else self.refill_rate
         key = f"rl:{ip}:{path}"
         now = time.time()
 
@@ -113,8 +129,8 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
                 _TOKEN_BUCKET_LUA,
                 1,
                 key,
-                self.capacity,
-                self.refill_rate,
+                capacity,
+                refill,
                 now,
                 1,
             )
@@ -133,12 +149,12 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
                 content={"error": "rate_limited", "retry_after": retry_after},
                 headers={
                     "Retry-After": str(retry_after),
-                    "X-RateLimit-Limit": str(self.capacity),
+                    "X-RateLimit-Limit": str(capacity),
                     "X-RateLimit-Remaining": "0",
                 },
             )
 
         response = await call_next(request)
-        response.headers["X-RateLimit-Limit"] = str(self.capacity)
+        response.headers["X-RateLimit-Limit"] = str(capacity)
         response.headers["X-RateLimit-Remaining"] = str(remaining)
         return response

--- a/backend/app/vault.py
+++ b/backend/app/vault.py
@@ -24,10 +24,13 @@ class VaultUnavailableError(HTTPException):
 class VaultService:
     """AES-256-GCM encryption service with HKDF key derivation."""
 
-    _SALT = b"gold-trading-bot-vault-v1"
+    # Default salt preserves backward compatibility with existing encrypted rows.
+    # Set VAULT_SALT env var to a deployment-unique value for new deployments.
+    _DEFAULT_SALT = b"gold-trading-bot-vault-v1"
     _INFO = b"secrets-encryption"
 
     def __init__(self, master_key: str | None):
+        self._salt = os.getenv("VAULT_SALT", "").encode() or self._DEFAULT_SALT
         self._derived_key: bytes | None = None
         if master_key:
             self._derived_key = self._derive_key(master_key)
@@ -37,7 +40,7 @@ class VaultService:
         return HKDF(
             algorithm=hashes.SHA256(),
             length=32,
-            salt=self._SALT,
+            salt=self._salt,
             info=self._INFO,
         ).derive(master_key.encode())
 

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -13,8 +13,11 @@ export default function LoginPage() {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    const isLocal = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1";
-    if (isLocal) {
+    // Dev-only auth bypass: must opt in via NEXT_PUBLIC_DEV_NOAUTH=1 on a local host.
+    const isLocal =
+      window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1";
+    const bypassEnabled = process.env.NEXT_PUBLIC_DEV_NOAUTH === "1";
+    if (isLocal && bypassEnabled) {
       localStorage.setItem("token", "__noauth__");
       router.replace("/dashboard");
     }


### PR DESCRIPTION
## Summary
Triage + fix subset of `jodunk`'s automated audit. Real issues fixed; subjective / false-positive ones closed separately.

## Fixes
- **#14 Vault salt** — `VAULT_SALT` env var, default keeps BC for existing ciphertexts.
- **#15 WebAuthn challenges** — Redis with 5 min TTL; process-local fallback for dev.
- **#16 Auth rate limit** — tighter bucket (5/min, burst 10) for `/api/auth/login`, `/login/options`, `/login/verify`, `/register/options`, `/register/verify`.
- **#17 `_positions_cache` race** — `asyncio.Lock` + double-check; prevents duplicate fetch on concurrent miss.
- **#19 Fire-and-forget tasks** — `_spawn_background` helper logs exceptions + keeps strong reference (prevents GC). Applied to order audit log + losing-streak alert.
- **#28 Localhost auth bypass** — requires explicit `NEXT_PUBLIC_DEV_NOAUTH=1` opt-in.

## Closed as won't-fix (see individual issues)
- #18 already mitigated + documented in `CLAUDE.md`.
- #20 no Kelly code exists — AI audit hallucination.
- #21, #22, #29, #30, #31, #37, #38 subjective refactor.
- #23 code already uses generic "Invalid credentials" — false positive.
- #24 HS256 acceptable for single-user deployment.
- #25 auth middleware disable is intentional (cross-origin cookie on Railway public suffix).
- #26 WS endpoint validates token via query param — false positive.
- #27 key rotation is a feature request, not a bug.
- #32 API timeouts are set per-call by domain need; centralizing adds indirection without value.

## Test plan
- [ ] `pytest tests/ -v --no-cov`
- [ ] `npx tsc --noEmit`
- [ ] Smoke: brute-force `POST /api/auth/login` 10× → receive 429 after bucket drains
- [ ] Smoke: `curl` vault-backed secret read still decrypts (BC verified)
- [ ] Smoke: hit `localhost:3000/login` without `NEXT_PUBLIC_DEV_NOAUTH` → stays on login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)