### PR TITLE
chore(alembic): make recent migrations idempotent

### DIFF
--- a/backend/alembic/versions/n4o5p6q7r8s9_add_performance_indexes.py
+++ b/backend/alembic/versions/n4o5p6q7r8s9_add_performance_indexes.py
@@ -6,6 +6,7 @@ Create Date: 2026-04-15 12:00:00.000000
 """
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 revision: str = "n4o5p6q7r8s9"
@@ -14,17 +15,26 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+_INDEXES = [
+    ("ix_trades_open_time", "trades", ["open_time"]),
+    ("ix_trades_close_time", "trades", ["close_time"]),
+    ("ix_trades_symbol_open_time", "trades", ["symbol", "open_time"]),
+    ("ix_bot_events_created_at", "bot_events", ["created_at"]),
+    ("ix_news_sentiments_created_at", "news_sentiments", ["created_at"]),
+]
+
+
 def upgrade() -> None:
-    op.create_index("ix_trades_open_time", "trades", ["open_time"])
-    op.create_index("ix_trades_close_time", "trades", ["close_time"])
-    op.create_index("ix_trades_symbol_open_time", "trades", ["symbol", "open_time"])
-    op.create_index("ix_bot_events_created_at", "bot_events", ["created_at"])
-    op.create_index("ix_news_sentiments_created_at", "news_sentiments", ["created_at"])
+    # Idempotent: tolerate indexes already created out-of-band (manual SQL,
+    # earlier deploy, etc.) so reruns don't fail.
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    for name, table, cols in _INDEXES:
+        existing = {i["name"] for i in inspector.get_indexes(table)}
+        if name not in existing:
+            op.create_index(name, table, cols)
 
 
 def downgrade() -> None:
-    op.drop_index("ix_news_sentiments_created_at", "news_sentiments")
-    op.drop_index("ix_bot_events_created_at", "bot_events")
-    op.drop_index("ix_trades_symbol_open_time", "trades")
-    op.drop_index("ix_trades_close_time", "trades")
-    op.drop_index("ix_trades_open_time", "trades")
+    for name, table, _ in reversed(_INDEXES):
+        op.drop_index(name, table)

--- a/backend/alembic/versions/o5p6q7r8s9t0_add_trade_is_archived.py
+++ b/backend/alembic/versions/o5p6q7r8s9t0_add_trade_is_archived.py
@@ -16,13 +16,22 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    # Raise lock_timeout for this statement to survive zero-downtime deploy
+    # Idempotent: the column + index may already exist when lifespan schema
+    # bootstrap added them on older deploys before this migration ran.
     op.execute("SET lock_timeout = '30s'")
-    op.add_column(
-        "trades",
-        sa.Column("is_archived", sa.Boolean(), nullable=False, server_default="false"),
-    )
-    op.create_index("ix_trades_is_archived", "trades", ["is_archived"])
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    columns = {c["name"] for c in inspector.get_columns("trades")}
+    if "is_archived" not in columns:
+        op.add_column(
+            "trades",
+            sa.Column("is_archived", sa.Boolean(), nullable=False, server_default="false"),
+        )
+
+    indexes = {i["name"] for i in inspector.get_indexes("trades")}
+    if "ix_trades_is_archived" not in indexes:
+        op.create_index("ix_trades_is_archived", "trades", ["is_archived"])
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/p6q7r8s9t0u1_add_ai_usage_logs.py
+++ b/backend/alembic/versions/p6q7r8s9t0u1_add_ai_usage_logs.py
@@ -16,27 +16,37 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    # Idempotent: the table + indexes may already exist from lifespan bootstrap
+    # on older deploys that ran before this migration.
     op.execute("SET lock_timeout = '30s'")
-    op.create_table(
-        "ai_usage_logs",
-        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
-        sa.Column("timestamp", sa.DateTime(), server_default=sa.func.now(), nullable=False),
-        sa.Column("agent_id", sa.String(100), nullable=False),
-        sa.Column("model", sa.String(100), nullable=False),
-        sa.Column("input_tokens", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("output_tokens", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("cache_read_tokens", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("cache_write_tokens", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("cost_usd_sdk", sa.Float(), nullable=True),
-        sa.Column("cost_usd_calc", sa.Float(), nullable=True),
-        sa.Column("duration_ms", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("turns", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("tool_calls_count", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("success", sa.Boolean(), nullable=False, server_default="true"),
-        sa.Column("raw_usage", sa.JSON(), nullable=True),
-    )
-    op.create_index("ix_ai_usage_logs_timestamp", "ai_usage_logs", ["timestamp"])
-    op.create_index("ix_ai_usage_logs_agent_id", "ai_usage_logs", ["agent_id"])
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if "ai_usage_logs" not in inspector.get_table_names():
+        op.create_table(
+            "ai_usage_logs",
+            sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+            sa.Column("timestamp", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+            sa.Column("agent_id", sa.String(100), nullable=False),
+            sa.Column("model", sa.String(100), nullable=False),
+            sa.Column("input_tokens", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("output_tokens", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("cache_read_tokens", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("cache_write_tokens", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("cost_usd_sdk", sa.Float(), nullable=True),
+            sa.Column("cost_usd_calc", sa.Float(), nullable=True),
+            sa.Column("duration_ms", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("turns", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("tool_calls_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("success", sa.Boolean(), nullable=False, server_default="true"),
+            sa.Column("raw_usage", sa.JSON(), nullable=True),
+        )
+
+    indexes = {i["name"] for i in inspector.get_indexes("ai_usage_logs")} if "ai_usage_logs" in inspector.get_table_names() else set()
+    if "ix_ai_usage_logs_timestamp" not in indexes:
+        op.create_index("ix_ai_usage_logs_timestamp", "ai_usage_logs", ["timestamp"])
+    if "ix_ai_usage_logs_agent_id" not in indexes:
+        op.create_index("ix_ai_usage_logs_agent_id", "ai_usage_logs", ["agent_id"])
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/q7r8s9t0u1v2_add_symbol_configs.py
+++ b/backend/alembic/versions/q7r8s9t0u1v2_add_symbol_configs.py
@@ -94,6 +94,11 @@ _SEED_ROWS = [
 
 def upgrade() -> None:
     op.execute("SET lock_timeout = '30s'")
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if "symbol_configs" in inspector.get_table_names():
+        # Already created out-of-band (e.g. manual SQL during incident recovery).
+        return
     op.create_table(
         "symbol_configs",
         sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),


### PR DESCRIPTION
## Problem
Migrations n4o5, o5p6, p6q7 fail on rerun with DuplicateColumn / DuplicateTable / DuplicateObject because the lifespan bootstrap in app/main.py creates the same schema via IF NOT EXISTS on every startup. When an older deploy ran the bootstrap first, the migrations stall forever.

Hit during production recovery today — alembic was stuck at l2m3n4o5p6q7 and `upgrade head` couldn't progress past o5p6 (is_archived column already existed).

## Fix
Each upgrade now inspects the DB and skips existing columns / tables / indexes:
- n4o5 — skip index creation if already present
- o5p6 — skip is_archived add + index if present
- p6q7 — skip ai_usage_logs CREATE + indexes if present
- q7r8 — skip symbol_configs CREATE if present

Downgrades untouched.

## Test plan
- [ ] `alembic upgrade head` on clean DB — all migrations apply
- [ ] `alembic upgrade head` when bootstrap columns/tables already exist — no error, version advances
- [ ] `alembic downgrade -1` followed by `upgrade +1` — same behavior