### PR TITLE
fix(mt5): resolve canonical symbol to broker alias at MT5 boundary

### DIFF
--- a/backend/app/api/routes/market_data.py
+++ b/backend/app/api/routes/market_data.py
@@ -22,13 +22,12 @@ async def get_ohlcv(
     count: int = Query(200, le=5000),
 ):
     engine = _get_engine(symbol)
-    # Use engine's actual symbol (may differ from alias, e.g., GOLDmicro vs GOLD)
-    actual_symbol = engine.symbol
-    df = await engine.market_data.get_ohlcv(actual_symbol, timeframe, count)
+    # market_data.get_ohlcv internally resolves canonical → broker alias
+    df = await engine.market_data.get_ohlcv(engine.symbol, timeframe, count)
     if df.empty:
         return {"candles": []}
 
-    profile = SYMBOL_PROFILES.get(actual_symbol, SYMBOL_PROFILES.get(symbol, {}))
+    profile = SYMBOL_PROFILES.get(engine.symbol, {})
     decimals = profile.get("price_decimals", 2)
 
     candles = []

--- a/backend/app/mt5/market_data.py
+++ b/backend/app/mt5/market_data.py
@@ -11,23 +11,10 @@ import pandas as pd
 from loguru import logger
 
 from app.mt5.connector import MT5BridgeConnector
+from app.mt5.symbol_resolver import to_broker_alias
 
 # Max tick age before considered stale (seconds)
 MAX_TICK_AGE_SECONDS = 30
-
-
-def _resolve_broker(symbol: str) -> str:
-    """Resolve canonical symbol → broker alias (e.g., GOLD → GOLDm#). No-op if already alias."""
-    try:
-        from app.config import SYMBOL_PROFILES
-        profile = SYMBOL_PROFILES.get(symbol)
-        if profile:
-            alias = profile.get("broker_alias")
-            if alias:
-                return alias
-    except Exception:
-        pass
-    return symbol
 
 
 class MarketDataService:
@@ -36,7 +23,7 @@ class MarketDataService:
         self._avg_spread: dict[str, float] = {}  # symbol → rolling avg spread
 
     async def get_current_tick(self, symbol: str, validate: bool = True) -> dict | None:
-        symbol = _resolve_broker(symbol)
+        symbol = to_broker_alias(symbol)
         result = await self.connector.get_tick(symbol)
         if not result.get("success"):
             logger.warning(f"Failed to get tick for {symbol}: {result.get('error')}")
@@ -76,7 +63,7 @@ class MarketDataService:
         return tick
 
     async def get_ohlcv(self, symbol: str, timeframe: str = "M15", count: int = 100, validate: bool = True) -> pd.DataFrame:
-        symbol = _resolve_broker(symbol)
+        symbol = to_broker_alias(symbol)
         result = await self.connector.get_ohlcv(symbol, timeframe, count)
         if not result.get("success") or not result.get("data"):
             logger.warning(f"Failed to get OHLCV for {symbol}: {result.get('error')}")
@@ -92,7 +79,7 @@ class MarketDataService:
 
     async def get_ohlcv_range(self, symbol: str, timeframe: str, from_date: str, to_date: str) -> pd.DataFrame:
         """Fetch historical OHLCV data by date range from MT5 Bridge."""
-        symbol = _resolve_broker(symbol)
+        symbol = to_broker_alias(symbol)
         result = await self.connector.get_ohlcv_range(symbol, timeframe, from_date, to_date)
         if not result.get("success") or not result.get("data"):
             logger.warning(f"Failed to get historical OHLCV for {symbol}: {result.get('error')}")

--- a/backend/app/mt5/market_data.py
+++ b/backend/app/mt5/market_data.py
@@ -16,12 +16,27 @@ from app.mt5.connector import MT5BridgeConnector
 MAX_TICK_AGE_SECONDS = 30
 
 
+def _resolve_broker(symbol: str) -> str:
+    """Resolve canonical symbol → broker alias (e.g., GOLD → GOLDm#). No-op if already alias."""
+    try:
+        from app.config import SYMBOL_PROFILES
+        profile = SYMBOL_PROFILES.get(symbol)
+        if profile:
+            alias = profile.get("broker_alias")
+            if alias:
+                return alias
+    except Exception:
+        pass
+    return symbol
+
+
 class MarketDataService:
     def __init__(self, connector: MT5BridgeConnector):
         self.connector = connector
         self._avg_spread: dict[str, float] = {}  # symbol → rolling avg spread
 
     async def get_current_tick(self, symbol: str, validate: bool = True) -> dict | None:
+        symbol = _resolve_broker(symbol)
         result = await self.connector.get_tick(symbol)
         if not result.get("success"):
             logger.warning(f"Failed to get tick for {symbol}: {result.get('error')}")
@@ -61,6 +76,7 @@ class MarketDataService:
         return tick
 
     async def get_ohlcv(self, symbol: str, timeframe: str = "M15", count: int = 100, validate: bool = True) -> pd.DataFrame:
+        symbol = _resolve_broker(symbol)
         result = await self.connector.get_ohlcv(symbol, timeframe, count)
         if not result.get("success") or not result.get("data"):
             logger.warning(f"Failed to get OHLCV for {symbol}: {result.get('error')}")
@@ -76,6 +92,7 @@ class MarketDataService:
 
     async def get_ohlcv_range(self, symbol: str, timeframe: str, from_date: str, to_date: str) -> pd.DataFrame:
         """Fetch historical OHLCV data by date range from MT5 Bridge."""
+        symbol = _resolve_broker(symbol)
         result = await self.connector.get_ohlcv_range(symbol, timeframe, from_date, to_date)
         if not result.get("success") or not result.get("data"):
             logger.warning(f"Failed to get historical OHLCV for {symbol}: {result.get('error')}")

--- a/backend/app/mt5/order_executor.py
+++ b/backend/app/mt5/order_executor.py
@@ -13,6 +13,20 @@ from app.mt5.connector import MT5BridgeConnector
 _NO_RETRY_ERRORS = {"margin", "insufficient", "invalid volume", "market closed", "symbol not found"}
 
 
+def _resolve_broker(symbol: str) -> str:
+    """Resolve canonical symbol → broker alias (e.g., GOLD → GOLDm#)."""
+    try:
+        from app.config import SYMBOL_PROFILES
+        profile = SYMBOL_PROFILES.get(symbol)
+        if profile:
+            alias = profile.get("broker_alias")
+            if alias:
+                return alias
+    except Exception:
+        pass
+    return symbol
+
+
 class OrderExecutor:
     def __init__(self, connector: MT5BridgeConnector):
         self.connector = connector
@@ -21,6 +35,7 @@ class OrderExecutor:
         self, symbol: str, order_type: str, lot: float, sl: float, tp: float,
         comment: str = "", magic: int = MT5_MAGIC_NUMBER, max_retries: int = 3,
     ) -> dict:
+        symbol = _resolve_broker(symbol)
         logger.info(f"Placing order: {order_type} {lot} {symbol} SL={sl} TP={tp}")
 
         for attempt in range(max_retries):
@@ -60,6 +75,8 @@ class OrderExecutor:
         return result
 
     async def close_all_positions(self, symbol: str | None = None) -> dict:
+        if symbol:
+            symbol = _resolve_broker(symbol)
         logger.warning(f"Closing ALL positions (symbol={symbol})")
         result = await self.connector.close_all_positions(symbol=symbol)
         return result
@@ -70,7 +87,8 @@ class OrderExecutor:
             return []
         positions = result.get("data", [])
         if symbol:
-            positions = [p for p in positions if p.get("symbol") == symbol]
+            broker = _resolve_broker(symbol)
+            positions = [p for p in positions if p.get("symbol") in (symbol, broker)]
         return positions
 
     async def modify_position(self, ticket: int, sl: float | None = None, tp: float | None = None) -> dict:

--- a/backend/app/mt5/order_executor.py
+++ b/backend/app/mt5/order_executor.py
@@ -8,23 +8,10 @@ from loguru import logger
 
 from app.constants import MT5_MAGIC_NUMBER
 from app.mt5.connector import MT5BridgeConnector
+from app.mt5.symbol_resolver import to_broker_alias
 
 # Errors that should NOT be retried (permanent failures)
 _NO_RETRY_ERRORS = {"margin", "insufficient", "invalid volume", "market closed", "symbol not found"}
-
-
-def _resolve_broker(symbol: str) -> str:
-    """Resolve canonical symbol → broker alias (e.g., GOLD → GOLDm#)."""
-    try:
-        from app.config import SYMBOL_PROFILES
-        profile = SYMBOL_PROFILES.get(symbol)
-        if profile:
-            alias = profile.get("broker_alias")
-            if alias:
-                return alias
-    except Exception:
-        pass
-    return symbol
 
 
 class OrderExecutor:
@@ -35,7 +22,7 @@ class OrderExecutor:
         self, symbol: str, order_type: str, lot: float, sl: float, tp: float,
         comment: str = "", magic: int = MT5_MAGIC_NUMBER, max_retries: int = 3,
     ) -> dict:
-        symbol = _resolve_broker(symbol)
+        symbol = to_broker_alias(symbol)
         logger.info(f"Placing order: {order_type} {lot} {symbol} SL={sl} TP={tp}")
 
         for attempt in range(max_retries):
@@ -76,7 +63,7 @@ class OrderExecutor:
 
     async def close_all_positions(self, symbol: str | None = None) -> dict:
         if symbol:
-            symbol = _resolve_broker(symbol)
+            symbol = to_broker_alias(symbol)
         logger.warning(f"Closing ALL positions (symbol={symbol})")
         result = await self.connector.close_all_positions(symbol=symbol)
         return result
@@ -87,7 +74,7 @@ class OrderExecutor:
             return []
         positions = result.get("data", [])
         if symbol:
-            broker = _resolve_broker(symbol)
+            broker = to_broker_alias(symbol)
             positions = [p for p in positions if p.get("symbol") in (symbol, broker)]
         return positions
 

--- a/backend/app/mt5/symbol_resolver.py
+++ b/backend/app/mt5/symbol_resolver.py
@@ -1,0 +1,22 @@
+"""Resolve canonical symbol (e.g. GOLD) to broker alias (e.g. GOLDm#) at the MT5 boundary.
+
+Distinct from `config.resolve_broker_symbol`, which normalizes user input to engine.symbol
+(canonical). This helper is the last-mile mapping applied immediately before calling MT5 Bridge.
+"""
+
+from app.config import SYMBOL_PROFILES
+
+
+def to_broker_alias(symbol: str) -> str:
+    """Return broker_alias for symbol if set in SYMBOL_PROFILES, else symbol itself.
+
+    Idempotent: passing an alias returns it unchanged when SYMBOL_PROFILES also keys it.
+    Safe pre-DB-load: returns symbol when profile or alias missing.
+    """
+    if not symbol:
+        return symbol
+    profile = SYMBOL_PROFILES.get(symbol)
+    if profile is None:
+        return symbol
+    alias = profile.get("broker_alias")
+    return alias if alias else symbol

--- a/backend/tests/unit/test_symbol_resolver.py
+++ b/backend/tests/unit/test_symbol_resolver.py
@@ -1,0 +1,52 @@
+"""Tests for canonical → broker alias resolution at the MT5 boundary."""
+
+import pytest
+
+from app.config import SYMBOL_PROFILES
+from app.mt5.symbol_resolver import to_broker_alias
+
+
+@pytest.fixture(autouse=True)
+def restore_profiles():
+    snapshot = dict(SYMBOL_PROFILES)
+    yield
+    SYMBOL_PROFILES.clear()
+    SYMBOL_PROFILES.update(snapshot)
+
+
+def test_returns_broker_alias_when_set():
+    SYMBOL_PROFILES["GOLD"] = {"broker_alias": "GOLDm#"}
+    assert to_broker_alias("GOLD") == "GOLDm#"
+
+
+def test_returns_symbol_when_alias_empty():
+    SYMBOL_PROFILES["EURUSD"] = {"broker_alias": ""}
+    assert to_broker_alias("EURUSD") == "EURUSD"
+
+
+def test_returns_symbol_when_alias_none():
+    SYMBOL_PROFILES["EURUSD"] = {"broker_alias": None}
+    assert to_broker_alias("EURUSD") == "EURUSD"
+
+
+def test_returns_symbol_when_no_alias_key():
+    SYMBOL_PROFILES["EURUSD"] = {"pip_value": 10}
+    assert to_broker_alias("EURUSD") == "EURUSD"
+
+
+def test_returns_symbol_when_profile_missing():
+    SYMBOL_PROFILES.pop("UNKNOWN", None)
+    assert to_broker_alias("UNKNOWN") == "UNKNOWN"
+
+
+def test_idempotent_on_alias_input():
+    SYMBOL_PROFILES["GOLDm#"] = {"broker_alias": "GOLDm#"}
+    assert to_broker_alias("GOLDm#") == "GOLDm#"
+
+
+def test_empty_input_returns_empty():
+    assert to_broker_alias("") == ""
+
+
+def test_none_input_returns_none():
+    assert to_broker_alias(None) is None


### PR DESCRIPTION
## Summary
- Chart + trading routes pass canonical symbol (e.g. \`GOLD\`) straight to MT5, which only accepts broker aliases (\`GOLDm#\`) → empty OHLCV, failed orders. Only EURUSD worked because canonical == alias.
- Centralize canonical → broker alias resolution inside \`MarketDataService\` and \`OrderExecutor\` via \`SYMBOL_PROFILES[canonical].broker_alias\`.
- One helper covers every call site: engine loop, strategies (regime/momentum/pair_spread/risk_parity), collector backfill, AI analyzers, API routes. No per-caller changes needed.

## Why
Users add a new symbol with broker alias, but chart stays blank and trades never fire because alias resolution never happened at the MT5 boundary.

## Test plan
- [ ] Add new symbol via Symbols page with broker_alias (e.g. GOLD / \`GOLDm#\`)
- [ ] Validate passes
- [ ] Enable + wait for market open
- [ ] Dashboard chart renders candles
- [ ] Engine places order via broker alias (check MT5 Bridge logs)
- [ ] EURUSD (no alias) still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)