### PR TITLE
fix(mcp): drop hardcoded GOLD fallback in risk manager

### DIFF
--- a/backend/mcp_server/tools/risk.py
+++ b/backend/mcp_server/tools/risk.py
@@ -5,8 +5,12 @@ from app.config import SYMBOL_PROFILES
 
 
 def _get_risk_manager(symbol: str = "GOLD") -> RiskManager:
-    """Create a RiskManager with symbol-specific profile."""
-    profile = SYMBOL_PROFILES.get(symbol, SYMBOL_PROFILES["GOLD"])
+    """Create a RiskManager with symbol-specific profile.
+
+    Falls back to defaults if symbol missing from SYMBOL_PROFILES — avoids KeyError
+    when GOLD profile is removed/renamed.
+    """
+    profile = SYMBOL_PROFILES.get(symbol) or {}
     return RiskManager(
         pip_value=profile.get("pip_value", 1.0),
         price_decimals=profile.get("price_decimals", 2),


### PR DESCRIPTION
## Summary
- \`_get_risk_manager\` used \`SYMBOL_PROFILES[\"GOLD\"]\` as a default. Footgun now that symbols are user-editable — removing/renaming GOLD crashes the tool.
- Replace with \`or {}\` so missing profile falls through to existing constructor defaults.

## Test plan
- [ ] Remove GOLD profile → \`calculate_lot\`/\`validate_trade\`/\`calculate_sl_tp\` no longer raise KeyError
- [ ] With GOLD present → same behavior as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)