### PR TITLE
feat(news): multi-symbol news sources + generic fallback

### DIFF
--- a/backend/app/news/fetcher.py
+++ b/backend/app/news/fetcher.py
@@ -85,10 +85,13 @@ class NewsFetcher:
         return self._dedup_and_limit(all_items)
 
     async def fetch_for_symbol(self, symbol: str) -> list[dict]:
-        from app.config import get_canonical_symbol
-        from app.news.sources import NEWS_SOURCES_BY_SYMBOL
+        from app.config import SYMBOL_PROFILES, get_canonical_symbol
+        from app.news.sources import NEWS_SOURCES_BY_SYMBOL, build_generic_sources
         canonical = get_canonical_symbol(symbol)
-        sources = NEWS_SOURCES_BY_SYMBOL.get(canonical, NEWS_SOURCES_BY_SYMBOL.get(symbol, NEWS_SOURCES_BY_SYMBOL.get("GOLD", [])))
+        sources = NEWS_SOURCES_BY_SYMBOL.get(canonical) or NEWS_SOURCES_BY_SYMBOL.get(symbol)
+        if not sources:
+            display = (SYMBOL_PROFILES.get(canonical) or SYMBOL_PROFILES.get(symbol) or {}).get("display_name")
+            sources = build_generic_sources(symbol, display)
         tasks = []
         for source in sources:
             if source["type"] == "rss":

--- a/backend/app/news/sources.py
+++ b/backend/app/news/sources.py
@@ -15,11 +15,13 @@ NEWS_SOURCES_BY_SYMBOL = {
         {"name": "Investing.com Economy RSS", "url": "https://www.investing.com/rss/news_14.rss", "type": "rss", "filter_keywords": ["gold", "XAU", "bullion", "Fed", "inflation", "dollar", "treasury"]},
         *_TRUMP_TRADE_SOURCES,
     ],
+    "XAUUSD": None,  # alias → resolved to GOLD below
     "OILCash": [
         {"name": "Google News Oil RSS", "url": "https://news.google.com/rss/search?q=crude+oil+WTI+price&hl=en&gl=US&ceid=US:en", "type": "rss", "filter_keywords": None},
         {"name": "Investing.com Economy RSS", "url": "https://www.investing.com/rss/news_14.rss", "type": "rss", "filter_keywords": ["oil", "crude", "WTI", "OPEC", "energy", "petroleum"]},
         *_TRUMP_TRADE_SOURCES,
     ],
+    "OIL": None,  # alias → resolved to OILCash below
     "BTCUSD": [
         {"name": "Google News Bitcoin RSS", "url": "https://news.google.com/rss/search?q=bitcoin+BTC+crypto+price&hl=en&gl=US&ceid=US:en", "type": "rss", "filter_keywords": None},
         {"name": "Investing.com Economy RSS", "url": "https://www.investing.com/rss/news_14.rss", "type": "rss", "filter_keywords": ["bitcoin", "crypto", "BTC", "blockchain", "SEC"]},
@@ -30,7 +32,46 @@ NEWS_SOURCES_BY_SYMBOL = {
         {"name": "Investing.com Economy RSS", "url": "https://www.investing.com/rss/news_14.rss", "type": "rss", "filter_keywords": ["yen", "JPY", "BOJ", "Japan", "dollar", "Fed"]},
         *_TRUMP_TRADE_SOURCES,
     ],
+    "EURUSD": [
+        {"name": "Google News EURUSD RSS", "url": "https://news.google.com/rss/search?q=EURUSD+euro+dollar+ECB+Fed&hl=en&gl=US&ceid=US:en", "type": "rss", "filter_keywords": None},
+        {"name": "Investing.com Economy RSS", "url": "https://www.investing.com/rss/news_14.rss", "type": "rss", "filter_keywords": ["euro", "EUR", "ECB", "eurozone", "dollar", "Fed"]},
+        *_TRUMP_TRADE_SOURCES,
+    ],
+    "US100": [
+        {"name": "Google News Nasdaq RSS", "url": "https://news.google.com/rss/search?q=Nasdaq+100+tech+stocks+earnings&hl=en&gl=US&ceid=US:en", "type": "rss", "filter_keywords": None},
+        {"name": "Investing.com Economy RSS", "url": "https://www.investing.com/rss/news_14.rss", "type": "rss", "filter_keywords": ["Nasdaq", "tech", "NVDA", "MSFT", "AAPL", "GOOGL", "AI", "earnings", "Fed"]},
+        *_TRUMP_TRADE_SOURCES,
+    ],
 }
+
+# Aliases → canonical. Saves duplication across XAUUSD/GOLD, OIL/OILCash, etc.
+_SYMBOL_ALIASES = {"XAUUSD": "GOLD", "OIL": "OILCash"}
+for _alias, _canonical in _SYMBOL_ALIASES.items():
+    NEWS_SOURCES_BY_SYMBOL[_alias] = NEWS_SOURCES_BY_SYMBOL[_canonical]
+
+
+def build_generic_sources(symbol: str, display_name: str | None = None) -> list[dict]:
+    """Fallback: build Google News RSS + Trump feeds from symbol name.
+
+    Used when NEWS_SOURCES_BY_SYMBOL has no explicit entry — keeps news relevant
+    for user-added symbols (ENJ, SOL, TSLA, etc.) without hand-written config.
+    """
+    from urllib.parse import quote_plus
+    query_parts = [symbol]
+    if display_name and display_name.lower() != symbol.lower():
+        query_parts.append(display_name)
+    query_parts.append("price")
+    query = quote_plus(" ".join(query_parts))
+    return [
+        {
+            "name": f"Google News {symbol} RSS",
+            "url": f"https://news.google.com/rss/search?q={query}&hl=en&gl=US&ceid=US:en",
+            "type": "rss",
+            "filter_keywords": None,
+        },
+        *_TRUMP_TRADE_SOURCES,
+    ]
+
 
 # Keep backward compat
 NEWS_SOURCES = NEWS_SOURCES_BY_SYMBOL.get("GOLD", [])


### PR DESCRIPTION
## Summary
\`NEWS_SOURCES_BY_SYMBOL\` only covered GOLD / OILCash / BTCUSD / USDJPY. User-added symbols (EURUSD / US100 / XAUUSD / ENJ) silently fell back to the GOLD feed → AI sentiment analyzed gold headlines as if they described the target symbol → garbage signals.

- **Add** explicit EURUSD and US100 entries
- **Alias** XAUUSD→GOLD and OIL→OILCash
- **Generic fallback** \`build_generic_sources(symbol, display_name)\` constructs a Google News RSS query from the symbol + display name for any future symbol (ENJ, SOL, TSLA, etc.)
- \`fetch_for_symbol\` uses the generic fallback instead of defaulting to GOLD

## Why
Symbols are user-editable via the Symbols page; the hardcoded dict doesn't scale, and a silent GOLD fallback poisons sentiment for every non-gold symbol.

## Test plan
- [ ] \`fetch_for_symbol(\"EURUSD\")\` pulls EUR/ECB/Fed headlines, not gold
- [ ] \`fetch_for_symbol(\"US100\")\` pulls Nasdaq / big-tech / AI headlines
- [ ] \`fetch_for_symbol(\"XAUUSD\")\` resolves alias → returns GOLD sources
- [ ] \`fetch_for_symbol(\"ENJ\")\` uses generic fallback with ENJ-specific query
- [ ] \`fetch_for_symbol(\"GOLD\")\` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)