### PR TITLE
fix(multi-symbol): dynamic cross-asset + drop silent GOLD defaults (audit batch 1+3)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -104,6 +104,19 @@ def resolve_broker_symbol(symbol: str) -> str:
         return symbol
 
 
+def get_active_symbols() -> list[str]:
+    """Return all active engine symbols, falling back to SYMBOL_PROFILES canonicals.
+
+    Prefers the live BotManager (reflects runtime add/remove via Symbols UI). Falls
+    back to non-alias profiles when the manager is unavailable (tests, startup).
+    """
+    try:
+        from app.api.routes.bot import get_manager
+        return list(get_manager().engines.keys())
+    except Exception:
+        return [sym for sym, p in SYMBOL_PROFILES.items() if "canonical" not in p]
+
+
 # Auto-register aliased profiles so SYMBOL_PROFILES["GOLDmicro"] works directly
 for _alias, _canonical in SYMBOL_ALIASES.items():
     if _canonical in SYMBOL_PROFILES and _alias not in SYMBOL_PROFILES:

--- a/backend/app/risk/correlation.py
+++ b/backend/app/risk/correlation.py
@@ -19,9 +19,6 @@ STATIC_CORRELATIONS = {
 # Backward compat alias
 CORRELATIONS = STATIC_CORRELATIONS
 
-# All symbol pairs to track
-ALL_SYMBOLS = ["GOLD", "OILCash", "BTCUSD", "USDJPY"]
-
 
 @dataclass
 class CorrelationMatrix:

--- a/backend/app/strategy/momentum_rank.py
+++ b/backend/app/strategy/momentum_rank.py
@@ -9,10 +9,9 @@ Worst case: momentum reversal — the strongest trending asset reverses sharply.
 
 import pandas as pd
 
+from app.config import get_active_symbols
 from app.strategy.base import BaseStrategy
 from app.strategy.indicators import atr, adx as calc_adx
-
-ALL_SYMBOLS = ["GOLD", "OILCash", "BTCUSD", "USDJPY"]
 
 
 class MomentumRankStrategy(BaseStrategy):
@@ -49,15 +48,18 @@ class MomentumRankStrategy(BaseStrategy):
         }
 
     async def _prepare_cross_data(self, market_data) -> None:
-        """Fetch N-bar returns for all symbols and rank them."""
+        """Fetch N-bar returns for active symbols and rank them."""
         import asyncio
         self._cross_returns = {}
+        active = get_active_symbols()
+        if len(active) < 2:
+            return  # Need at least 2 symbols to rank
         try:
             dfs = await asyncio.gather(*[
                 market_data.get_ohlcv(sym, "M15", self._lookback + 10)
-                for sym in ALL_SYMBOLS
+                for sym in active
             ])
-            for sym, df in zip(ALL_SYMBOLS, dfs):
+            for sym, df in zip(active, dfs):
                 if df is not None and not df.empty and len(df) >= self._lookback + 1:
                     close_now = df["close"].iloc[-1]
                     close_prev = df["close"].iloc[-self._lookback]

--- a/backend/app/strategy/risk_parity.py
+++ b/backend/app/strategy/risk_parity.py
@@ -9,11 +9,9 @@ Worst case: low-volatility asset gets oversized position, then volatility spikes
 
 import pandas as pd
 
+from app.config import get_active_symbols
 from app.strategy.base import BaseStrategy
 from app.strategy.indicators import atr, ema
-
-
-ALL_SYMBOLS = ["GOLD", "OILCash", "BTCUSD", "USDJPY"]
 
 
 class RiskParityStrategy(BaseStrategy):
@@ -54,15 +52,18 @@ class RiskParityStrategy(BaseStrategy):
         }
 
     async def _prepare_cross_data(self, market_data) -> None:
-        """Fetch ATR of all symbols and compute inverse-volatility weights."""
+        """Fetch ATR of active symbols and compute inverse-volatility weights."""
         import asyncio
         atr_pcts = {}
+        active = get_active_symbols()
+        if len(active) < 2:
+            return
         try:
             dfs = await asyncio.gather(*[
                 market_data.get_ohlcv(sym, "M15", self._vol_lookback + 20)
-                for sym in ALL_SYMBOLS
+                for sym in active
             ])
-            for sym, df in zip(ALL_SYMBOLS, dfs):
+            for sym, df in zip(active, dfs):
                 if df is not None and not df.empty and len(df) >= self._atr_period + 2:
                     atr_val = atr(df["high"], df["low"], df["close"], self._atr_period).iloc[-1]
                     price = df["close"].iloc[-1]

--- a/backend/mcp_server/agent_config.py
+++ b/backend/mcp_server/agent_config.py
@@ -76,11 +76,15 @@ async def run_multi_agent(
 def _build_user_message(job_type: str, job_input: dict | None) -> str:
     input_str = json.dumps(job_input, default=str) if job_input else "{}"
     if job_type == "candle_analysis":
-        symbol = (job_input or {}).get("symbol", "GOLD")
+        symbol = (job_input or {}).get("symbol")
+        if not symbol:
+            raise ValueError("candle_analysis job requires 'symbol' in job_input")
         timeframe = (job_input or {}).get("timeframe", "M15")
         return f"A new {timeframe} candle has closed for {symbol}. Analyze market conditions, detect regime, flag risks. Trading is handled by the strategy engine.\n\nJob input: {input_str}"
     elif job_type == "manual_analysis":
-        symbol = (job_input or {}).get("symbol", "GOLD")
+        symbol = (job_input or {}).get("symbol")
+        if not symbol:
+            raise ValueError("manual_analysis job requires 'symbol' in job_input")
         return f"Manual analysis requested for {symbol}. Provide thorough analysis with recommendation.\n\nJob input: {input_str}"
     elif job_type == "weekly_review":
         return f"Perform a weekly trading review.\n\nJob input: {input_str}"

--- a/backend/mcp_server/agents/orchestrator.py
+++ b/backend/mcp_server/agents/orchestrator.py
@@ -100,7 +100,9 @@ async def run_multi_agent(
         Combined result with all agent reports and final decision.
     """
     start_time = time.time()
-    symbol = (job_input or {}).get("symbol", "GOLD")
+    symbol = (job_input or {}).get("symbol")
+    if not symbol:
+        raise ValueError("multi-agent run requires 'symbol' in job_input")
     timeframe = (job_input or {}).get("timeframe", "M15")
 
     logger.info(f"[Orchestrator] Starting multi-agent analysis: {symbol} {timeframe}")

--- a/backend/mcp_server/agents/prompt_registry.py
+++ b/backend/mcp_server/agents/prompt_registry.py
@@ -51,6 +51,9 @@ def _load_defaults() -> None:
     from app.ai.prompts import OPTIMIZATION_SYSTEM_PROMPT
     from app.ai.prompts import get_sentiment_prompt
 
+    # Sentiment default uses a `{symbol}` placeholder so the /agent-prompts UI
+    # displays the generic template instead of a gold-specific variant.
+    # Runtime sentiment calls in app/ai/news_sentiment.py pass the real symbol.
     _DEFAULTS.update({
         "orchestrator": ORCH,
         "technical_analyst": TECH,
@@ -58,7 +61,7 @@ def _load_defaults() -> None:
         "risk_analyst": RISK,
         "reflector": REFL,
         "single_agent": single,
-        "sentiment": get_sentiment_prompt("GOLD"),
+        "sentiment": get_sentiment_prompt("{symbol}"),
         "optimization": OPTIMIZATION_SYSTEM_PROMPT,
     })
     _defaults_loaded = True

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -199,7 +199,7 @@ def create_server() -> FastMCP:
         return await learning.analyze_recent_trades(days, symbol)
 
     @mcp.tool()
-    async def detect_regime(symbol: str = "GOLD", timeframe: str = "M15") -> dict:
+    async def detect_regime(symbol: str, timeframe: str = "M15") -> dict:
         """Detect current market regime (trending/ranging/volatile/transitional)."""
         return await learning.detect_regime(symbol, timeframe)
 
@@ -238,7 +238,7 @@ def create_server() -> FastMCP:
         return strategy_gen.get_strategy_profiles()
 
     @mcp.tool()
-    async def recommend_strategy(regime: str, symbol: str = "GOLD") -> dict:
+    async def recommend_strategy(regime: str, symbol: str) -> dict:
         """Recommend the best strategy for the current market regime."""
         return strategy_gen.recommend_strategy(regime, symbol)
 
@@ -276,7 +276,7 @@ def create_server() -> FastMCP:
     @mcp.tool()
     async def compute_overfitting_score(
         strategy: str,
-        symbol: str = "GOLD",
+        symbol: str,
         timeframe: str = "M15",
         source: str = "db",
         count: int = 5000,
@@ -299,7 +299,7 @@ def create_server() -> FastMCP:
         return await strategy_switch.apply_strategy(symbol, strategy_name, params, reasoning)
 
     @mcp.tool()
-    async def get_switch_status(symbol: str = "GOLD") -> dict:
+    async def get_switch_status(symbol: str) -> dict:
         """Get auto-strategy-switch status: enabled, current strategy, cooldown, daily count."""
         return await strategy_switch.get_switch_status(symbol)
 

--- a/backend/mcp_server/tools/learning.py
+++ b/backend/mcp_server/tools/learning.py
@@ -104,7 +104,7 @@ async def get_optimization_history(limit: int = 5) -> dict:
         return {"error": f"Failed to fetch optimization history: {e}"}
 
 
-async def detect_regime(symbol: str = "GOLD", timeframe: str = "M15") -> dict:
+async def detect_regime(symbol: str, timeframe: str = "M15") -> dict:
     """Detect the current market regime (trending/ranging/volatile).
 
     Uses ATR and ADX from the full analysis to classify the regime.

--- a/backend/mcp_server/tools/overfitting.py
+++ b/backend/mcp_server/tools/overfitting.py
@@ -7,7 +7,7 @@ from mcp_server.tools import backend_url as _backend_url
 
 async def compute_overfitting_score(
     strategy: str,
-    symbol: str = "GOLD",
+    symbol: str,
     timeframe: str = "M15",
     source: str = "db",
     count: int = 5000,

--- a/backend/mcp_server/tools/strategy_gen.py
+++ b/backend/mcp_server/tools/strategy_gen.py
@@ -67,7 +67,7 @@ def get_strategy_profiles() -> dict:
     }
 
 
-def recommend_strategy(regime: str, symbol: str = "GOLD") -> dict:
+def recommend_strategy(regime: str, symbol: str) -> dict:
     """Recommend the best strategy for the current market regime.
 
     Args:

--- a/backend/mcp_server/tools/strategy_switch.py
+++ b/backend/mcp_server/tools/strategy_switch.py
@@ -123,7 +123,7 @@ async def apply_strategy(
     return response
 
 
-async def get_switch_status(symbol: str = "GOLD") -> dict:
+async def get_switch_status(symbol: str) -> dict:
     """Get current auto-strategy-switch status for a symbol.
 
     Args:

--- a/backend/tests/unit/test_multi_symbol_hardening.py
+++ b/backend/tests/unit/test_multi_symbol_hardening.py
@@ -1,0 +1,88 @@
+"""Unit tests for multi-symbol hardening (batch 1 + 3).
+
+Covers:
+- get_active_symbols fallback path (no BotManager → SYMBOL_PROFILES keys)
+- agent_config raises ValueError when job_input lacks 'symbol'
+- prompt_registry sentiment default contains `{symbol}` placeholder, not literal GOLD
+"""
+
+import pytest
+
+from app.config import SYMBOL_PROFILES, get_active_symbols
+
+
+@pytest.fixture(autouse=True)
+def restore_profiles():
+    snapshot = dict(SYMBOL_PROFILES)
+    yield
+    SYMBOL_PROFILES.clear()
+    SYMBOL_PROFILES.update(snapshot)
+
+
+def test_get_active_symbols_falls_back_to_profiles_when_no_manager():
+    SYMBOL_PROFILES.clear()
+    SYMBOL_PROFILES["GOLD"] = {"pip_value": 1}
+    SYMBOL_PROFILES["EURUSD"] = {"pip_value": 10}
+    # alias entries must be excluded
+    SYMBOL_PROFILES["GOLDm#"] = {"pip_value": 1, "canonical": "GOLD"}
+
+    active = get_active_symbols()
+
+    assert "GOLD" in active
+    assert "EURUSD" in active
+    assert "GOLDm#" not in active
+
+
+def test_get_active_symbols_returns_list_even_when_empty():
+    SYMBOL_PROFILES.clear()
+    assert get_active_symbols() == []
+
+
+def test_agent_config_candle_analysis_requires_symbol():
+    from mcp_server.agent_config import _build_user_message
+
+    with pytest.raises(ValueError, match="symbol"):
+        _build_user_message("candle_analysis", {})
+
+    with pytest.raises(ValueError, match="symbol"):
+        _build_user_message("candle_analysis", None)
+
+
+def test_agent_config_manual_analysis_requires_symbol():
+    from mcp_server.agent_config import _build_user_message
+
+    with pytest.raises(ValueError, match="symbol"):
+        _build_user_message("manual_analysis", {"timeframe": "M15"})
+
+
+def test_agent_config_accepts_valid_symbol():
+    from mcp_server.agent_config import _build_user_message
+
+    msg = _build_user_message("candle_analysis", {"symbol": "EURUSD", "timeframe": "M15"})
+    assert "EURUSD" in msg
+    assert "M15" in msg
+
+
+def test_agent_config_weekly_review_no_symbol_required():
+    from mcp_server.agent_config import _build_user_message
+
+    # weekly_review shouldn't require symbol
+    msg = _build_user_message("weekly_review", None)
+    assert "weekly trading review" in msg
+
+
+def test_prompt_registry_sentiment_default_is_symbol_agnostic():
+    from mcp_server.agents import prompt_registry
+
+    # Force reload to pick up new default
+    prompt_registry._defaults_loaded = False
+    prompt_registry._DEFAULTS.clear()
+
+    default = prompt_registry.get_default_prompt("sentiment")
+
+    # Old behavior baked "GOLD" literal; new behavior uses {symbol} placeholder
+    assert "{symbol}" in default
+    # Must not contain the literal hardcoded "GOLD " in instructional text
+    # (the word "GOLD" may still appear in the asset-class framework examples)
+    # Key invariant: the target instrument slot is a placeholder.
+    assert "headlines for the instrument **{symbol}**" in default

--- a/backend/tests/unit/test_phase_e.py
+++ b/backend/tests/unit/test_phase_e.py
@@ -44,21 +44,21 @@ class TestGetStrategyProfiles:
 
 class TestRecommendStrategy:
     def test_trending_recommends_ema(self):
-        result = recommend_strategy("trending")
+        result = recommend_strategy("trending", "GOLD")
         rec_name = result["recommended"]["name"]
         assert rec_name in ("ema_crossover", "breakout")
 
     def test_ranging_recommends_mean_reversion(self):
-        result = recommend_strategy("ranging")
+        result = recommend_strategy("ranging", "GOLD")
         rec_name = result["recommended"]["name"]
         assert rec_name in ("mean_reversion", "rsi_filter")
 
     def test_unknown_regime_returns_ensemble(self):
-        result = recommend_strategy("unknown_regime")
+        result = recommend_strategy("unknown_regime", "GOLD")
         assert result["recommended"]["name"] == "ensemble"
 
     def test_includes_alternatives(self):
-        result = recommend_strategy("trending")
+        result = recommend_strategy("trending", "GOLD")
         assert "alternatives" in result
         assert "other_strategies" in result
 


### PR DESCRIPTION
## Summary

Part of the multi-symbol hardening audit ([plan](../../../.claude/plans/investigate-config-wiggly-gosling.md)). Resolves audit findings #3 (cross-asset ALL_SYMBOLS hardcoded) and #4-5 (MCP agents/tools silently default to GOLD).

### Batch 1 — cross-asset strategies

- \`app/config.py\` — new \`get_active_symbols()\` helper. Prefers live \`BotManager.engines.keys()\`; falls back to \`SYMBOL_PROFILES\` canonicals (excluding alias entries) for tests/startup.
- \`app/strategy/momentum_rank.py\`, \`risk_parity.py\` — drop module-level \`ALL_SYMBOLS = [\"GOLD\",\"OILCash\",\"BTCUSD\",\"USDJPY\"]\`. Use \`get_active_symbols()\`. Skip when < 2 symbols active.
- \`app/risk/correlation.py\` — drop unused \`ALL_SYMBOLS\` constant.

### Batch 3 — MCP GOLD defaults

- \`mcp_server/agent_config.py\` — \`_build_user_message\` raises \`ValueError\` when candle_analysis / manual_analysis job_input lacks \`symbol\` (was silent GOLD default).
- \`mcp_server/agents/orchestrator.py\` — \`run_multi_agent\` raises when symbol missing.
- \`mcp_server/server.py\` — \`detect_regime\`, \`recommend_strategy\`, \`compute_overfitting_score\`, \`get_switch_status\` now require \`symbol\` param.
- \`mcp_server/tools/{learning,strategy_switch,strategy_gen,overfitting}.py\` — same: required \`symbol\`.
- \`mcp_server/agents/prompt_registry.py\` — sentiment default uses \`{symbol}\` placeholder so /agent-prompts UI shows a generic framework template instead of a gold-specific baked prompt.

## Deferred to follow-up PRs

- **Batch 2** — \`asset_class\` column + Alembic migration + \`app/market/sessions.py\` module to replace hardcoded \`MARKET_SCHEDULE\` and \`MARKET_RESET_HOURS\` dicts (audit findings #1-2).
- **Batch 4** — legacy cleanup (\`settings.symbol\`, ML route defaults, telegram \`SYMBOL_TH\`, \`ml_strategy.py\` default model_path).

## Test plan

- [x] \`tests/unit/test_multi_symbol_hardening.py\` covers \`get_active_symbols\` fallback, missing-symbol ValueError, placeholder in sentiment default
- [ ] Existing CI passes (ruff + pytest)
- [ ] Manual: trigger candle_analysis job without \`symbol\` → 400, not silent GOLD
- [ ] Manual: add a new symbol via /symbols → momentum_rank + risk_parity include it in ranking

🤖 Generated with [Claude Code](https://claude.com/claude-code)