### PR TITLE
fix(deploy): Dockerfile CMD fails fast on migration error

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -30,4 +30,4 @@ ENV PYTHONPATH=/app
 
 EXPOSE 8080
 
-CMD ["sh", "-c", "echo '[migration] start' && timeout 120 alembic upgrade head 2>&1 && echo '[migration] ok' || echo '[migration] FAILED'; uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8080} --timeout-keep-alive 30"]
+CMD ["sh", "-c", "echo '[migration] start' && timeout 120 alembic upgrade head 2>&1 && echo '[migration] ok' && exec uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8080} --timeout-keep-alive 30"]


### PR DESCRIPTION
## Summary

Old CMD swallowed alembic failures via \`|| echo '[migration] FAILED'\` then booted uvicorn anyway. PR #61 deploy hit this — column \`asset_class\` migration silently failed, backend served 500s for \`/api/symbols\`, browser reported as CORS error (5xx strips CORS headers).

New CMD chains migration success → \`exec uvicorn\`. Migration failure = container exit, Railway keeps last working revision live.

## Test plan

- [ ] Next deploy with passing migration → backend boots normally
- [ ] Synthetic broken migration → container fails to start, previous revision still serves traffic
- [ ] Railway rollback works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)