### PR TITLE
fix(deploy): trust Railway proxy headers

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -30,4 +30,4 @@ ENV PYTHONPATH=/app
 
 EXPOSE 8080
 
-CMD ["sh", "-c", "echo '[migration] start' && timeout 120 alembic upgrade head 2>&1 && echo '[migration] ok' && exec uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8080} --timeout-keep-alive 30"]
+CMD ["sh", "-c", "echo '[migration] start' && timeout 120 alembic upgrade head 2>&1 && echo '[migration] ok' && exec uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8080} --timeout-keep-alive 30 --proxy-headers --forwarded-allow-ips=*"]


### PR DESCRIPTION
## Summary
- uvicorn default `--forwarded-allow-ips=127.0.0.1` ignored Railway's proxy, causing 307 redirects to `http://` behind HTTPS edge
- Browser blocked redirects as mixed-content → surfaced as "No Access-Control-Allow-Origin header" CORS errors on `POST /api/symbols` and any slash-normalized path
- Add `--proxy-headers --forwarded-allow-ips=*` so uvicorn honors `X-Forwarded-Proto: https` from Railway

## Test plan
- [ ] Railway redeploy succeeds
- [ ] `curl -I https://backend-production-36d76.up.railway.app/api/symbols/` returns 307 with `Location: https://...` (not `http://`)
- [ ] Add symbol via UI saves without CORS error

🤖 Generated with [Claude Code](https://claude.com/claude-code)