### PR TITLE
fix(symbols): revive soft-deleted row on create

### DIFF
--- a/backend/app/api/routes/symbols.py
+++ b/backend/app/api/routes/symbols.py
@@ -10,6 +10,7 @@ from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException, Request
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator, model_validator
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.audit import log_audit
@@ -247,14 +248,37 @@ async def create_symbol(
     if await svc.get_config(db, req.symbol):
         raise HTTPException(status_code=409, detail=f"Symbol '{req.symbol}' already exists")
 
-    cfg = SymbolConfig(**req.model_dump(), is_enabled=False, ml_status="pending")
-    db.add(cfg)
-    await _audit(db, request, "symbol_created", req.symbol, {"broker_alias": req.broker_alias})
+    # Check for soft-deleted row with same symbol — revive it instead of INSERT
+    # (DB has a unique constraint on `symbol`, so a raw INSERT would fail with
+    # IntegrityError when a previously-deleted row is still present).
+    existing_deleted = await db.execute(
+        select(SymbolConfig).where(
+            SymbolConfig.symbol == req.symbol,
+            SymbolConfig.is_deleted.is_(True),
+        )
+    )
+    cfg = existing_deleted.scalar_one_or_none()
+    action = "symbol_created"
+    if cfg is not None:
+        for field, value in req.model_dump().items():
+            setattr(cfg, field, value)
+        cfg.is_deleted = False
+        cfg.is_enabled = False
+        cfg.ml_status = "pending"
+        cfg.ml_last_trained_at = None
+        cfg.updated_at = datetime.utcnow()
+        cfg.updated_by = "owner"
+        action = "symbol_revived"
+    else:
+        cfg = SymbolConfig(**req.model_dump(), is_enabled=False, ml_status="pending")
+        db.add(cfg)
+
+    await _audit(db, request, action, req.symbol, {"broker_alias": req.broker_alias})
     await db.commit()
     await db.refresh(cfg)
     await _publish(request, req.symbol, "created")
 
-    logger.info(f"Symbol created: {req.symbol}")
+    logger.info(f"Symbol {action}: {req.symbol}")
     return SymbolResponse.model_validate(cfg)
 
 

--- a/backend/tests/integration/test_api_symbols.py
+++ b/backend/tests/integration/test_api_symbols.py
@@ -125,6 +125,28 @@ class TestCRUD:
         assert resp.status_code == 404
 
     @pytest.mark.asyncio
+    async def test_recreate_after_delete_revives_row(self, client):
+        # create → delete → create again with different values should succeed
+        # (DB has unique constraint on `symbol`, so raw INSERT would fail)
+        await client.post("/api/symbols", json=_sample_create())
+        await client.delete("/api/symbols/EURUSD")
+
+        revived = _sample_create()
+        revived["display_name"] = "Revived EUR"
+        revived["max_lot"] = 7.5
+        resp = await client.post("/api/symbols", json=revived)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["symbol"] == "EURUSD"
+        assert body["display_name"] == "Revived EUR"
+        assert body["max_lot"] == 7.5
+        assert body["ml_status"] == "pending"
+
+        # visible again in list
+        resp = await client.get("/api/symbols")
+        assert any(c["symbol"] == "EURUSD" for c in resp.json())
+
+    @pytest.mark.asyncio
     async def test_get_not_found(self, client):
         resp = await client.get("/api/symbols/UNKNOWN")
         assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- Root cause of user's "Network Error / CORS" on recreating ENJUSD, BTCUSD, GOLD etc: DB has unique constraint on `symbol_configs.symbol`. Soft-deleted rows (is_deleted=True) block fresh INSERT → IntegrityError → 500 → Railway edge strips CORS header → browser misreports as CORS block.
- Fix: `create_symbol` now checks for a soft-deleted row with same canonical symbol and revives it (resets fields, ml_status=pending, is_deleted=False) instead of raw INSERT.
- Audit log distinguishes revive ("symbol_revived") from new creation.
- New integration test: create → delete → create again succeeds.

## Affected rows in prod DB (all is_deleted=True, blocking recreate)
- ENJ, ENJUSD, BTCUSD, EURUSD, GOLD, GOLDm, OILCash, USDJPY

## Test plan
- [ ] `pytest tests/integration/test_api_symbols.py::TestCRUD::test_recreate_after_delete_revives_row`
- [ ] Deploy → user retries Add Symbol with ENJUSD → saves, row visible in list

🤖 Generated with [Claude Code](https://claude.com/claude-code)