### PR TITLE
fix(multi-symbol): engine lifecycle correctness under hot-reload

### DIFF
--- a/backend/app/bot/engine.py
+++ b/backend/app/bot/engine.py
@@ -1491,7 +1491,14 @@ class BotEngine:
             logger.error(f"Failed to push event: {e}")
 
     async def _recover_pending_trades(self):
-        """Recover trades that failed DB save and were stored in Redis fallback."""
+        """Recover trades that failed DB save and were stored in Redis fallback.
+
+        Runs on a 5-minute scheduler cadence concurrently with candle/tick jobs.
+        Uses an isolated session per trade so a concurrent op on self.db cannot
+        raise "concurrent operations are not permitted" from asyncpg.
+        """
+        from app.db.session import async_session
+
         key = f"pending_trades:{self.symbol}"
         try:
             pending = await self.redis.lrange(key, 0, -1)
@@ -1514,16 +1521,13 @@ class BotEngine:
                         open_time=datetime.fromisoformat(data["open_time"]) if data.get("open_time") else _naive_utc(),
                         strategy_name=data.get("strategy_name"),
                     )
-                    self.db.add(trade)
-                    await self.db.commit()
+                    async with async_session() as session:
+                        session.add(trade)
+                        await session.commit()
                     await self.redis.lrem(key, 1, raw)
                     logger.info(f"Recovered pending trade: ticket={data['ticket']}")
                 except Exception as e:
                     logger.warning(f"Failed to recover pending trade: {e}")
-                    try:
-                        await self.db.rollback()
-                    except Exception:
-                        pass
         except Exception as e:
             logger.error(f"Pending trades recovery error [{self.symbol}]: {e}")
 

--- a/backend/app/bot/manager.py
+++ b/backend/app/bot/manager.py
@@ -33,10 +33,14 @@ class BotManager:
         self._positions_cache: dict[str, list[dict]] = {}
         self._positions_cache_time: float = 0
         self._positions_lock = asyncio.Lock()
+        self._engines_lock = asyncio.Lock()
         self._reload_task: asyncio.Task | None = None
         self._sentiment_analyzer = None
         self._notifier = None
         self._binance_connector = None
+        # Optional back-reference set by BotScheduler so reload_engines() can
+        # re-register cron candle jobs for newly-added symbols.
+        self._scheduler = None
         # Prefer DB-sourced enable flags; fall back to env-var symbol list when empty.
         db_enabled = [
             s for s, p in SYMBOL_PROFILES.items()
@@ -65,6 +69,13 @@ class BotManager:
 
     def get_symbols(self) -> list[str]:
         return list(self.engines.keys())
+
+    def engines_snapshot(self) -> dict[str, BotEngine]:
+        """Return a shallow copy safe to iterate during concurrent reloads."""
+        return dict(self.engines)
+
+    def set_scheduler(self, scheduler) -> None:
+        self._scheduler = scheduler
 
     async def start(self, symbol: str | None = None):
         """Start one or all engines."""
@@ -188,41 +199,52 @@ class BotManager:
         return engine
 
     async def reload_engines(self) -> dict:
-        """Rebuild engine set from current SYMBOL_PROFILES + is_enabled flags."""
-        enabled = {
-            s for s, p in SYMBOL_PROFILES.items()
-            if p.get("is_enabled") is True and "canonical" not in p
-        }
-        if not enabled:
-            # Backward compat: fall back to env-var symbol list when DB empty.
-            enabled = set(settings.symbol_list)
+        """Rebuild engine set from current SYMBOL_PROFILES + is_enabled flags.
 
-        current = set(self.engines.keys())
-        to_add = enabled - current
-        to_remove = current - enabled
-        to_update = enabled & current
+        Serialized by _engines_lock so concurrent pubsub + direct reload calls
+        cannot produce partial dict state visible to iterating scheduler jobs.
+        """
+        async with self._engines_lock:
+            enabled = {
+                s for s, p in SYMBOL_PROFILES.items()
+                if p.get("is_enabled") is True and "canonical" not in p
+            }
+            if not enabled:
+                enabled = set(settings.symbol_list)
 
-        stop_coros = [self.engines.pop(s).stop() for s in to_remove]
-        if stop_coros:
-            await asyncio.gather(*stop_coros, return_exceptions=True)
+            current = set(self.engines.keys())
+            to_add = enabled - current
+            to_remove = current - enabled
+            to_update = enabled & current
 
-        for symbol in to_add:
+            stop_coros = [self.engines.pop(s).stop() for s in to_remove]
+            if stop_coros:
+                await asyncio.gather(*stop_coros, return_exceptions=True)
+
+            for symbol in to_add:
+                try:
+                    self.engines[symbol] = self._build_engine(symbol, SYMBOL_PROFILES.get(symbol, {}))
+                except Exception as e:
+                    logger.error(f"BotManager: create {symbol} failed: {e}")
+
+            for symbol in to_update:
+                profile = SYMBOL_PROFILES.get(symbol)
+                if profile:
+                    self.engines[symbol].apply_profile(profile)
+
+            summary = {
+                "added": sorted(to_add),
+                "removed": sorted(to_remove),
+                "updated": sorted(to_update),
+                "active": sorted(self.engines.keys()),
+            }
+
+        if self._scheduler is not None and (to_add or to_remove):
             try:
-                self.engines[symbol] = self._build_engine(symbol, SYMBOL_PROFILES.get(symbol, {}))
+                self._scheduler.reschedule_candle_jobs()
             except Exception as e:
-                logger.error(f"BotManager: create {symbol} failed: {e}")
+                logger.warning(f"BotManager: scheduler candle reschedule failed: {e}")
 
-        for symbol in to_update:
-            profile = SYMBOL_PROFILES.get(symbol)
-            if profile:
-                self.engines[symbol].apply_profile(profile)
-
-        summary = {
-            "added": sorted(to_add),
-            "removed": sorted(to_remove),
-            "updated": sorted(to_update),
-            "active": sorted(self.engines.keys()),
-        }
         logger.info(f"BotManager reload: {summary}")
         return summary
 

--- a/backend/app/bot/scheduler.py
+++ b/backend/app/bot/scheduler.py
@@ -45,6 +45,7 @@ class BotScheduler:
         if isinstance(manager, BotManager):
             self.manager = manager
             self._legacy_bot: BotEngine | None = None
+            manager.set_scheduler(self)
         else:
             # Backward compat: wrap single engine
             self.manager = None
@@ -53,6 +54,7 @@ class BotScheduler:
         self.scheduler = AsyncIOScheduler()
         self._candle_job_ids: dict[str, str] = {}  # timeframe → job_id
         self._health_monitor = None  # set via set_health_monitor()
+        self._background_tasks: set[asyncio.Task] = set()
 
     def set_health_monitor(self, monitor):
         self._health_monitor = monitor
@@ -278,13 +280,34 @@ class BotScheduler:
         self._schedule_candle_jobs()
         logger.info(f"Candle jobs rescheduled after {symbol} changed to {timeframe}")
 
+    def reschedule_candle_jobs(self) -> None:
+        """Rebuild candle cron jobs for the current engine set.
+
+        Called by BotManager.reload_engines() after adding or removing engines
+        so new symbols start receiving candle ticks without a process restart.
+        """
+        self._schedule_candle_jobs()
+
     def stop(self):
         self.scheduler.shutdown(wait=False)
         logger.info("Scheduler stopped")
 
+    def _track_task(self, coro) -> asyncio.Task:
+        """Spawn a background task and hold a strong reference so it is not GC'd."""
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return task
+
+    def _engines_snapshot(self) -> dict[str, BotEngine]:
+        """Return a stable snapshot for iteration independent of reload_engines."""
+        if self.manager:
+            return self.manager.engines_snapshot()
+        return dict(self._engines)
+
     async def _tick_job(self):
         # Fetch ticks for ALL symbols (even STOPPED) so dashboard shows prices
-        tasks = [self._fetch_tick(sym, eng) for sym, eng in self._engines.items()]
+        tasks = [self._fetch_tick(sym, eng) for sym, eng in self._engines_snapshot().items()]
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
 
@@ -324,18 +347,19 @@ class BotScheduler:
         if not active_symbols:
             return
 
+        engines = self._engines_snapshot()
         if trading_mode == "strategy":
             for sym in active_symbols:
-                engine = self._engines.get(sym)
+                engine = engines.get(sym)
                 if engine and engine.state.value == "RUNNING":
                     try:
                         await engine.process_candle()
                     except Exception as e:
                         logger.error(f"process_candle error [{sym}]: {e}")
-            asyncio.create_task(self._run_ai_agent(active_symbols))
+            self._track_task(self._run_ai_agent(active_symbols))
         else:
             for sym in active_symbols:
-                engine = self._engines.get(sym)
+                engine = engines.get(sym)
                 if engine and engine.state.value == "RUNNING":
                     try:
                         await engine._detect_regime()
@@ -350,7 +374,7 @@ class BotScheduler:
         to reduce unnecessary API calls (~50% reduction).
         """
         tasks = []
-        for sym, engine in self._engines.items():
+        for sym, engine in self._engines_snapshot().items():
             if engine.state != BotState.RUNNING:
                 continue
             if not is_market_open(sym):
@@ -451,14 +475,14 @@ class BotScheduler:
         await asyncio.gather(*[_run_for_symbol(sym) for sym in symbols], return_exceptions=True)
 
     async def _sync_job(self):
-        tasks = [e.sync_positions() for e in self._engines.values() if e.state.value == "RUNNING"]
+        tasks = [e.sync_positions() for e in self._engines_snapshot().values() if e.state.value == "RUNNING"]
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
 
     async def _weekly_optimize_job(self):
         logger.info("Weekly optimization triggered")
         # Run optimization on first engine that has an optimizer
-        for engine in self._engines.values():
+        for engine in self._engines_snapshot().values():
             if not engine._optimizer or engine.strategy is None:
                 continue
             try:
@@ -498,7 +522,7 @@ class BotScheduler:
     async def _macro_collect_job(self):
         logger.info("Daily macro collection triggered")
         # Macro data is global, just use first engine
-        for engine in self._engines.values():
+        for engine in self._engines_snapshot().values():
             if hasattr(engine, '_macro_service') and engine._macro_service:
                 try:
                     stats = await engine._macro_service.collect_all()
@@ -509,7 +533,7 @@ class BotScheduler:
 
     async def _refresh_economic_calendar(self):
         """Refresh economic calendar from API for all engines."""
-        for engine in self._engines.values():
+        for engine in self._engines_snapshot().values():
             try:
                 count = await engine._event_calendar.refresh()
                 logger.debug(f"Economic calendar refreshed: {count} events")
@@ -519,7 +543,7 @@ class BotScheduler:
 
     async def _daily_reset_job(self):
         logger.info("Daily reset triggered")
-        tasks = [e.circuit_breaker.reset() for e in self._engines.values()]
+        tasks = [e.circuit_breaker.reset() for e in self._engines_snapshot().values()]
         await asyncio.gather(*tasks, return_exceptions=True)
 
     async def _ai_usage_cleanup_job(self):
@@ -559,7 +583,7 @@ class BotScheduler:
 
             from app.db.session import async_session
 
-            for symbol, engine in self._engines.items():
+            for symbol, engine in self._engines_snapshot().items():
                 # Get today's closed trades — use an isolated session so a
                 # dirty engine.db doesn't taint the daily summary job.
                 today_start = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=None)
@@ -589,7 +613,7 @@ class BotScheduler:
             total_win_rate = total_wins / total_trades if total_trades > 0 else 0
 
             # Send via first engine's notifier
-            notifier = next((e.notifier for e in self._engines.values() if e.notifier), None)
+            notifier = next((e.notifier for e in self._engines_snapshot().values() if e.notifier), None)
             if notifier:
                 await notifier.send_daily_summary(symbol_stats, round(total_pnl, 2), total_trades, total_win_rate)
                 logger.info(f"Daily summary sent: PnL=${total_pnl:.2f}, trades={total_trades}")
@@ -599,7 +623,7 @@ class BotScheduler:
     async def _ml_retrain_job(self):
         """Weekly ML retrain — trains per-symbol on last 6 months of data."""
         logger.info("Weekly ML retrain triggered")
-        for symbol, engine in self._engines.items():
+        for symbol, engine in self._engines_snapshot().items():
             await self._ml_retrain_symbol(symbol, engine)
 
     async def _status_broadcast_job(self):
@@ -631,14 +655,14 @@ class BotScheduler:
             await self._health_monitor.check()
 
     async def _pending_trades_recovery_job(self):
-        tasks = [e._recover_pending_trades() for e in self._engines.values()]
+        tasks = [e._recover_pending_trades() for e in self._engines_snapshot().values()]
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
 
     async def _reconciliation_job(self):
         tasks = [
             e.reconcile_positions()
-            for e in self._engines.values()
+            for e in self._engines_snapshot().values()
             if e.state.value in ("RUNNING", "PAUSED") and not e.paper_trade
         ]
         if tasks:


### PR DESCRIPTION
## Summary
Follow-up to today's audit (PR #66-#69). Five multi-symbol lifecycle bugs fixed:

1. **Candle jobs never rescheduled after reload** — new symbols added via /api/symbols got a BotEngine but no cron candle job → no regime, no AI, no process_candle. Fixed by invoking \`scheduler.reschedule_candle_jobs()\` from \`reload_engines()\`.

2. **Dict race on iteration** — \`manager.engines.pop(s)\` in reload_engines mutates the dict while \`_tick_job\`, \`_sentiment_job\`, \`_sync_job\`, \`_reconciliation_job\`, \`_pending_trades_recovery_job\`, \`_weekly_optimize_job\`, \`_daily_summary_job\`, \`_ml_retrain_job\`, \`_macro_collect_job\`, \`_refresh_economic_calendar\` iterate. New \`engines_snapshot()\` on BotManager returns a shallow copy for iteration. \`reload_engines()\` also now serialized under an asyncio.Lock.

3. **Orphan AI agent task** — \`asyncio.create_task(self._run_ai_agent(...))\` in \`_candle_job\` wasn't held → Python could GC mid-run, losing the decision. New \`_track_task()\` keeps a strong reference until completion.

4. **_recover_pending_trades used shared engine.db** — 5-minute recovery job racing with \`process_candle()\` → "concurrent operations are not permitted" from asyncpg. Switched to isolated \`async_session\` per trade insert.

5. \`BotManager.set_scheduler()\` back-reference so reload callbacks can reach the scheduler.

Deferred to later PRs:
- Dashboard \"pending vs default\" UX for Regime/Sentiment/AI Analysis
- Asset-class-aware health monitor (forex close shouldn't pause crypto)
- BotEngine shared session refactor (larger scope)

## Test plan
- [ ] After deploy: add a new symbol → confirm logs show \`Candle job scheduled for M15 ([OIL, US100, XAUUSD, ENJUSD])\`
- [ ] Dashboard for the new symbol shows regime updating within one candle close
- [ ] No \"dictionary changed size during iteration\" errors under load
- [ ] \`_recover_pending_trades\` runs without asyncpg concurrency errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)