### PR TITLE
feat: production hardening — symbol auto-trade, money correctness, OWASP top 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,13 @@ jobs:
 
       - name: Type check (mypy)
         run: mypy app/ --ignore-missing-imports
-        continue-on-error: true  # typing baseline debt — tighten once cleaned
+        # mypy still has untyped baseline debt; gate stays soft until the
+        # baseline is annotated. Track in TODO. Remove ``continue-on-error``
+        # once ``mypy app/`` returns clean to make typing breakage block merge.
+        continue-on-error: true
 
       - name: Run tests with coverage
-        run: pytest --cov=app --cov-report=term-missing --cov-fail-under=25
+        run: pytest --cov=app --cov-report=term-missing --cov-fail-under=30
 
   frontend:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,13 +172,17 @@ railway vars set -s backend "KEY=value"  # set env var
 
 ## Important Patterns
 
-- **Auth**: Using Bearer token auth (username/password). `AuthMiddleware` (WebAuthn) disabled in `main.py`. `require_auth` dependency checks `Authorization: Bearer <token>` header. Frontend stores token in localStorage. Tests bypass auth via `AUTH_PASSWORD_HASH=""` in conftest.py.
-- **DB session**: Shared session can get dirty — always `rollback()` before new operations in long-lived services
-- **SYMBOL_PROFILES**: Per-symbol config in config.py (timeframe, pip_value, SL/TP mults, ML defaults)
+- **Auth**: Using Bearer token auth (username/password). Login uses constant-time bcrypt regardless of username match (timing-oracle fix). `AuthMiddleware` (WebAuthn) disabled in `main.py`. `require_auth` dependency checks `Authorization: Bearer <token>` header. Frontend stores token in localStorage. Tests bypass auth via `AUTH_PASSWORD_HASH=""` in conftest.py.
+- **Router auth**: Use `app.api.router_factory.make_authed_router(prefix, tags)` for new routers — applies `Depends(require_auth)` at router level so endpoints can not silently ship unauthenticated.
+- **DB session**: Shared `BotEngine.db` is the legacy long-lived session. New code MUST use `app.db.session.transaction()` (commits + rolls back automatically) or `async_session()` directly. `_log_event` already opens its own session per call to avoid asyncpg "concurrent operations" errors when multiple scheduler jobs touch the engine simultaneously.
+- **Lot sizing**: `RiskManager.calculate_lot_size(balance, sl_distance, ...)` and `calculate_kelly_size(...)` take a **price-unit distance** (NOT pips). Formula uses `contract_size` directly — passing the wrong unit silently mis-sizes trades. Originally used `pip_value × 100`, only correct for GOLD; broken for OIL / BTC / USDJPY (10×–100× off).
+- **SYMBOL_PROFILES**: Per-symbol config in config.py (timeframe, pip_value, SL/TP mults, ML defaults). Use `AssetClass` enum (in `app.market.sessions`) instead of raw strings when comparing or constructing.
 - **Constants**: All magic numbers in `constants.py` — never hardcode
-- **Tests**: 444 tests across 27 files. SQLite in-memory for DB, fakeredis, mock MT5 connector. Auth disabled via `os.environ["AUTH_PASSWORD_HASH"] = ""` in conftest.py. SDK mocks use `type` attribute instead of `isinstance`.
+- **Tests**: 454+ tests across 27 files. SQLite in-memory for DB, fakeredis, mock MT5 connector. Auth disabled via `os.environ["AUTH_PASSWORD_HASH"] = ""` in conftest.py. SDK mocks use `type` attribute instead of `isinstance`. mcp-dependent tests need `claude-agent-sdk` package.
 - **Runner**: `RunnerManager` init in `main.py` lifespan. Uses `ProcessRunnerBackend` by default (Railway-compatible). Heartbeat monitor runs as APScheduler job. Job queue uses dual Redis+DB storage. Runner logs streamed via Redis pub/sub to WebSocket.
-- **Coverage**: CI threshold 25% (overall ~29%, critical paths ~89%)
+- **DB pool**: Default `db_pool_size=8`, `max_overflow=12` (Railway Hobby plan caps connections at 25). Bump in env on Pro plans.
+- **Daily reset**: Per-asset-class hour from `app.market.sessions._RULES` — forex/metal/energy reset at 22 UTC, index 22, stock 21, crypto 0. Scheduler registers one cron job per unique reset hour across active engines.
+- **Coverage**: CI threshold 30% (overall ~29%, critical paths ~89%)
 - **Telegram**: Notifications for trade signals, AI analysis, system alerts. Thai language alerts.
 
 ## Known Issues
@@ -192,6 +196,12 @@ railway vars set -s backend "KEY=value"  # set env var
 - Deploy: Railway uses Dockerfile CMD, NOT Procfile — always edit `backend/Dockerfile` line 33 for startup changes
 - Deploy: Alembic migration can hang on table lock during zero-downtime deploy (old instance holds locks) — mitigated with `timeout 30` in CMD + `lock_timeout = 5s` in alembic/env.py and lifespan
 - Alembic: Never reuse revision IDs — each migration file must have a unique revision and correct down_revision chain
+- Alembic: `s9t0u1v2w3x4` adds performance indexes (idempotent, fast). `t0u1v2w3x4y5` converts `JSON` columns to `JSONB` — runs `ALTER TYPE jsonb USING col::jsonb` per column, takes ACCESS EXCLUSIVE lock, **maintenance window required** for large tables.
+- Backups: APScheduler runs `scripts/backup_db.sh` daily at 02:30 UTC when `ENABLE_DB_BACKUPS=1` is set. No-op otherwise so dev environments stay clean.
+- Production env vars: `TRUSTED_HOSTS` (comma-separated, blocks Host header injection), `VAULT_SALT` (random per deployment), `ENABLE_DB_BACKUPS=1`, `INTERNAL_API_TOKEN` is minted on startup with 24h expiry.
+- Sentry: set `SENTRY_DSN`, optional `SENTRY_ENVIRONMENT` / `SENTRY_TRACES_SAMPLE_RATE`. SDK initialized at module import in `main.py:_init_sentry()` so import-time errors are captured. PII suppressed via `send_default_pii=False`.
+- Rate limit: token bucket per (identity, path). Identity = JWT subject when bearer token decodes, else trusted client IP. Auth endpoints always bucket by IP (user not yet identified). Configure via `rate_limit_per_minute` / `rate_limit_burst` env vars.
+- PgBouncer: set `db_pgbouncer_mode=true` when routing through transaction-mode pooling. Disables asyncpg statement cache (cache is per-connection, breaks under transaction-mode pool reuse). Recommended pool sizing in PgBouncer mode: `db_pool_size=2-3`, `db_max_overflow=5` — PgBouncer handles the real concurrency, the SQLAlchemy pool only owns server connections.
 
 ## User Preferences (from memory)
 

--- a/backend/alembic/versions/s9t0u1v2w3x4_add_perf_indexes.py
+++ b/backend/alembic/versions/s9t0u1v2w3x4_add_perf_indexes.py
@@ -1,0 +1,82 @@
+"""add performance + soft-delete + foreign-key indexes
+
+Revision ID: s9t0u1v2w3x4
+Revises: r8s9t0u1v2w3
+Create Date: 2026-05-03 12:00:00.000000
+
+Adds composite + partial indexes flagged by the production audit:
+- ``ix_trades_symbol_close_time`` — daily summary queries filter on both columns
+- ``ix_runner_logs_runner_id`` — runner observability reads
+- ``ix_runner_metrics_runner_id`` — runner metrics reads
+- ``ix_runner_jobs_runner_id`` — job queue lookups
+- ``ix_secrets_active`` — partial index on ``key`` WHERE not deleted
+- ``ix_symbol_configs_active`` — partial index on ``symbol`` WHERE not deleted
+- ``ix_audit_logs_created_at`` — time-range scans
+- ``ix_audit_logs_action_created`` — composite for ``WHERE action=? AND created_at>=?``
+- ``ix_ohlcv_data_symbol_tf_time`` — composite covering load_from_db filter
+
+Uses ``IF NOT EXISTS`` so re-running on a partially-applied DB is safe.
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+from alembic import op
+
+revision: str = "s9t0u1v2w3x4"
+down_revision: str | None = "r8s9t0u1v2w3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_INDEXES = [
+    (
+        "ix_trades_symbol_close_time",
+        "CREATE INDEX IF NOT EXISTS ix_trades_symbol_close_time "
+        "ON trades (symbol, close_time) WHERE is_archived = false",
+    ),
+    (
+        "ix_runner_logs_runner_id",
+        "CREATE INDEX IF NOT EXISTS ix_runner_logs_runner_id ON runner_logs (runner_id)",
+    ),
+    (
+        "ix_runner_metrics_runner_id",
+        "CREATE INDEX IF NOT EXISTS ix_runner_metrics_runner_id ON runner_metrics (runner_id)",
+    ),
+    (
+        "ix_runner_jobs_runner_id",
+        "CREATE INDEX IF NOT EXISTS ix_runner_jobs_runner_id ON runner_jobs (runner_id)",
+    ),
+    (
+        "ix_secrets_active",
+        "CREATE INDEX IF NOT EXISTS ix_secrets_active ON secrets (key) WHERE is_deleted = false",
+    ),
+    (
+        "ix_symbol_configs_active",
+        "CREATE INDEX IF NOT EXISTS ix_symbol_configs_active "
+        "ON symbol_configs (symbol) WHERE is_deleted = false",
+    ),
+    (
+        "ix_audit_logs_created_at",
+        "CREATE INDEX IF NOT EXISTS ix_audit_logs_created_at ON audit_logs (created_at)",
+    ),
+    (
+        "ix_audit_logs_action_created",
+        "CREATE INDEX IF NOT EXISTS ix_audit_logs_action_created ON audit_logs (action, created_at)",
+    ),
+    (
+        "ix_ohlcv_data_symbol_tf_time",
+        "CREATE INDEX IF NOT EXISTS ix_ohlcv_data_symbol_tf_time "
+        "ON ohlcv_data (symbol, timeframe, time DESC)",
+    ),
+]
+
+
+def upgrade() -> None:
+    for _, sql in _INDEXES:
+        op.execute(sql)
+
+
+def downgrade() -> None:
+    for name, _ in _INDEXES:
+        op.execute(f"DROP INDEX IF EXISTS {name}")

--- a/backend/alembic/versions/t0u1v2w3x4y5_json_to_jsonb.py
+++ b/backend/alembic/versions/t0u1v2w3x4y5_json_to_jsonb.py
@@ -1,0 +1,56 @@
+"""convert JSON columns to JSONB
+
+Revision ID: t0u1v2w3x4y5
+Revises: s9t0u1v2w3x4
+Create Date: 2026-05-03 12:30:00.000000
+
+PostgreSQL ``JSON`` stores raw text and re-parses on every read; ``JSONB`` stores
+a parsed binary representation, supports GIN indexing, and is faster for reads.
+
+Affected columns:
+- audit_logs.detail
+- trades.pre_trade_snapshot
+- trades.post_trade_analysis
+- runners.tags, runners.resource_limits
+- runner_jobs.input, runner_jobs.output
+- agent_memory.evidence
+- ai_usage_logs.raw_usage
+
+Each ``ALTER COLUMN ... TYPE jsonb USING col::jsonb`` takes an
+``ACCESS EXCLUSIVE`` lock for the duration of the rewrite. Run during a
+maintenance window. Safe on empty / small tables; multi-GB tables may need
+``pg_repack`` instead.
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+from alembic import op
+
+revision: str = "t0u1v2w3x4y5"
+down_revision: str | None = "s9t0u1v2w3x4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_JSONB_TARGETS = [
+    ("audit_logs", "detail"),
+    ("trades", "pre_trade_snapshot"),
+    ("trades", "post_trade_analysis"),
+    ("runners", "tags"),
+    ("runners", "resource_limits"),
+    ("runner_jobs", "input"),
+    ("runner_jobs", "output"),
+    ("agent_memory", "evidence"),
+    ("ai_usage_logs", "raw_usage"),
+]
+
+
+def upgrade() -> None:
+    for table, column in _JSONB_TARGETS:
+        op.execute(f"ALTER TABLE {table} ALTER COLUMN {column} TYPE jsonb USING {column}::jsonb")
+
+
+def downgrade() -> None:
+    for table, column in _JSONB_TARGETS:
+        op.execute(f"ALTER TABLE {table} ALTER COLUMN {column} TYPE json USING {column}::json")

--- a/backend/alembic/versions/u1v2w3x4y5z6_add_model_digest.py
+++ b/backend/alembic/versions/u1v2w3x4y5z6_add_model_digest.py
@@ -1,0 +1,33 @@
+"""add ml_model_logs.model_digest for HMAC integrity check
+
+Revision ID: u1v2w3x4y5z6
+Revises: t0u1v2w3x4y5
+Create Date: 2026-05-03 13:00:00.000000
+
+Adds a nullable HMAC-SHA256 hex column populated at training time and verified
+before joblib.load(). Existing rows have NULL digests; the loader rejects them
+unless ``ML_DIGEST_REQUIRED=0`` is set during a one-time grace period so an
+operator can re-train without simultaneously losing all models.
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "u1v2w3x4y5z6"
+down_revision: str | None = "t0u1v2w3x4y5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "ml_model_logs",
+        sa.Column("model_digest", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("ml_model_logs", "model_digest")

--- a/backend/app/api/router_factory.py
+++ b/backend/app/api/router_factory.py
@@ -1,0 +1,16 @@
+"""Shared router constructor — applies auth uniformly so a new file does not
+forget the dependency.
+
+A bare ``APIRouter()`` ships endpoints unauthenticated by default. We have been
+bitten by that twice (strategy.py, /health/pool). Routers that should require
+auth must use :func:`make_authed_router` so the dependency is attached at the
+router level, not opt-in per endpoint.
+"""
+
+from fastapi import APIRouter, Depends
+
+from app.auth import require_auth
+
+
+def make_authed_router(prefix: str, tags: list[str]) -> APIRouter:
+    return APIRouter(prefix=prefix, tags=tags, dependencies=[Depends(require_auth)])

--- a/backend/app/api/routes/data.py
+++ b/backend/app/api/routes/data.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from app.auth import require_auth
 
-router = APIRouter(prefix="/api/data", tags=["data"])
+router = APIRouter(prefix="/api/data", tags=["data"], dependencies=[Depends(require_auth)])
 
 _collector = None
 
@@ -30,7 +30,7 @@ class CollectRequest(BaseModel):
     to_date: str
 
 
-@router.post("/collect", dependencies=[Depends(require_auth)])
+@router.post("/collect")
 async def collect_data(req: CollectRequest):
     from app.config import resolve_broker_symbol
 

--- a/backend/app/api/routes/macro.py
+++ b/backend/app/api/routes/macro.py
@@ -9,7 +9,7 @@ from app.auth import require_auth
 from app.config import settings
 from app.db.session import get_db
 
-router = APIRouter(prefix="/api/macro", tags=["macro"])
+router = APIRouter(prefix="/api/macro", tags=["macro"], dependencies=[Depends(require_auth)])
 
 _macro_service = None
 _event_calendar = None

--- a/backend/app/api/routes/ml.py
+++ b/backend/app/api/routes/ml.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy import desc, select
+from sqlalchemy.orm import defer
 
 from app.auth import require_auth
 from app.config import resolve_broker_symbol, settings
@@ -143,6 +144,8 @@ async def train_model(req: TrainRequest):
             )
 
             split_idx = int(len(X) * (1 - req.test_size))
+            from app.ml.integrity import compute_model_digest
+
             log = MLModelLog(
                 model_name=model_name,
                 timeframe=req.timeframe,
@@ -154,6 +157,7 @@ async def train_model(req: TrainRequest):
                 feature_importance=json.dumps(result.feature_importance),
                 model_path=model_path,
                 model_binary=model_bytes,
+                model_digest=compute_model_digest(model_bytes),
                 is_active=True,
             )
             _db_session.add(log)
@@ -179,15 +183,22 @@ async def model_status(symbol: str = Query("GOLD")):
 
     model_prefix = f"lightgbm_{symbol.lower()}"
 
-    # Try symbol-specific model first
+    # Status reads metadata only — defer the LargeBinary blob (10-50MB per row)
+    # so /status doesn't pull the full model into memory each call.
+    blob_defer = defer(MLModelLog.model_binary)
+
     result = await _db_session.execute(
-        select(MLModelLog).where(MLModelLog.is_active, MLModelLog.model_name.like(f"{model_prefix}%")).limit(1)
+        select(MLModelLog)
+        .where(MLModelLog.is_active, MLModelLog.model_name.like(f"{model_prefix}%"))
+        .options(blob_defer)
+        .limit(1)
     )
     log = result.scalar_one_or_none()
 
-    # Fallback to any active model
     if not log:
-        result = await _db_session.execute(select(MLModelLog).where(MLModelLog.is_active).limit(1))
+        result = await _db_session.execute(
+            select(MLModelLog).where(MLModelLog.is_active).options(blob_defer).limit(1)
+        )
         log = result.scalar_one_or_none()
 
     if not log:
@@ -222,13 +233,25 @@ async def predict_now(symbol: str = Query("GOLD")):
     symbol = resolve_broker_symbol(symbol)
     model_prefix = f"lightgbm_{symbol.lower()}"
 
-    # Try loading symbol-specific model from file first
+    # Try loading symbol-specific model from file first. Resolve the path and
+    # confirm it is inside ``models/`` so a malformed symbol cannot escape the
+    # directory and joblib.load() arbitrary local files (pickle = RCE).
     from pathlib import Path
 
-    model_data = None
-    symbol_path = f"models/{symbol.lower()}_signal.pkl"
+    from app.api.routes.symbols import _validate_symbol_name
 
-    if Path(symbol_path).exists():
+    model_data = None
+    try:
+        _validate_symbol_name(symbol)
+    except ValueError:
+        return {"error": "Invalid symbol name"}
+
+    models_root = Path("models").resolve()
+    symbol_path = (models_root / f"{symbol.lower()}_signal.pkl").resolve()
+    if models_root not in symbol_path.parents and symbol_path.parent != models_root:
+        return {"error": "Path traversal rejected"}
+
+    if symbol_path.exists():
         model_data = joblib.load(symbol_path)
     elif Path(settings.ml_model_path).exists():
         model_data = joblib.load(settings.ml_model_path)
@@ -258,6 +281,10 @@ async def predict_now(symbol: str = Query("GOLD")):
             )
             log = result.scalar_one_or_none()
         if log and log.model_binary:
+            from app.ml.integrity import verify_model_digest
+
+            if not verify_model_digest(log.model_binary, log.model_digest, context=f"predict[{symbol}]"):
+                return {"error": "model integrity check failed — refuse to load (re-train required)"}
             buf = io.BytesIO(log.model_binary)
             model_data = joblib.load(buf)
 
@@ -308,6 +335,7 @@ async def predict_now(symbol: str = Query("GOLD")):
                 MLModelLog.is_active,
                 MLModelLog.model_name.like(f"{model_prefix}%"),
             )
+            .options(defer(MLModelLog.model_binary))
             .limit(1)
         )
         model_log = model_result.scalar_one_or_none()
@@ -346,6 +374,7 @@ async def get_drift_report(symbol: str = Query("GOLD")):
     result = await _db_session.execute(
         select(MLModelLog)
         .where(MLModelLog.is_active, MLModelLog.model_name.like(f"lightgbm_{symbol.lower()}%"))
+        .options(defer(MLModelLog.model_binary))
         .limit(1)
     )
     model_log = result.scalar_one_or_none()

--- a/backend/app/api/routes/ml.py
+++ b/backend/app/api/routes/ml.py
@@ -196,9 +196,7 @@ async def model_status(symbol: str = Query("GOLD")):
     log = result.scalar_one_or_none()
 
     if not log:
-        result = await _db_session.execute(
-            select(MLModelLog).where(MLModelLog.is_active).options(blob_defer).limit(1)
-        )
+        result = await _db_session.execute(select(MLModelLog).where(MLModelLog.is_active).options(blob_defer).limit(1))
         log = result.scalar_one_or_none()
 
     if not log:

--- a/backend/app/api/routes/positions.py
+++ b/backend/app/api/routes/positions.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, Query
 from app.api.routes.bot import _get_engine, get_manager
 from app.auth import require_auth
 
-router = APIRouter(prefix="/api/positions", tags=["positions"])
+router = APIRouter(prefix="/api/positions", tags=["positions"], dependencies=[Depends(require_auth)])
 
 
 @router.get("")
@@ -32,7 +32,7 @@ async def get_positions(symbol: str | None = Query(None)):
     return {"positions": all_positions}
 
 
-@router.delete("/{ticket}", dependencies=[Depends(require_auth)])
+@router.delete("/{ticket}")
 async def close_position(ticket: int):
     mgr = get_manager()
     # Use first engine's executor (they share the same connector)

--- a/backend/app/api/routes/strategy.py
+++ b/backend/app/api/routes/strategy.py
@@ -2,12 +2,13 @@
 Strategy API routes.
 """
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from app.api.routes.bot import _get_engine
+from app.auth import require_auth
 from app.strategy import STRATEGIES
 
-router = APIRouter(prefix="/api/strategy", tags=["strategy"])
+router = APIRouter(prefix="/api/strategy", tags=["strategy"], dependencies=[Depends(require_auth)])
 
 
 @router.get("/available")

--- a/backend/app/api/routes/symbols.py
+++ b/backend/app/api/routes/symbols.py
@@ -24,7 +24,19 @@ router = APIRouter(prefix="/api/symbols", tags=["symbols"])
 
 Timeframe = Literal["M1", "M5", "M15", "M30", "H1", "H4", "D1"]
 MLStatus = Literal["pending", "training", "ready", "failed"]
+# Pattern for the canonical symbol identifier. Allows broker-style names like
+# "USDJPYm", "OILCash", "GOLD.fx". The disallowed substring guard below blocks
+# ``..`` so the symbol cannot be used to escape a directory when interpolated
+# into a model file path (``models/{symbol}_signal.pkl``).
 _SYMBOL_PATTERN = re.compile(r"^[A-Za-z0-9._-]{2,32}$")
+
+
+def _validate_symbol_name(symbol: str) -> str:
+    if not _SYMBOL_PATTERN.match(symbol):
+        raise ValueError("symbol must be alphanumeric (2-32 chars, . _ - allowed)")
+    if ".." in symbol or symbol.startswith(".") or symbol.startswith("-"):
+        raise ValueError("symbol must not start with '.'/'-' or contain '..'")
+    return symbol
 
 
 # ─── Schemas ──────────────────────────────────────────────────────────────────
@@ -113,9 +125,7 @@ class SymbolCreateRequest(SymbolBase):
     @field_validator("symbol")
     @classmethod
     def _check_symbol(cls, v: str) -> str:
-        if not _SYMBOL_PATTERN.match(v):
-            raise ValueError("symbol must be alphanumeric (2-32 chars, . _ - allowed)")
-        return v
+        return _validate_symbol_name(v)
 
 
 class SymbolUpdateRequest(SymbolBase):
@@ -212,6 +222,70 @@ async def _reload_engines_direct(request: Request) -> None:
         logger.warning(f"Direct engine reload failed (pubsub will retry): {e}")
 
 
+# Cap concurrent bootstrap tasks so a burst of /symbols POST requests cannot
+# exhaust the DB connection pool. Each task does a multi-minute ML retrain that
+# holds a session for its duration; without this gate, 5 simultaneous adds eat
+# 5 connections from a pool of ~20.
+_BOOTSTRAP_SEMAPHORE = asyncio.Semaphore(2)
+
+
+async def _bootstrap_new_symbol(app_state, symbol: str, timeframe: str, days: int = 90) -> None:
+    """Seed historical OHLCV + kick off ML retrain for a freshly-created symbol.
+
+    Runs as a background task — caller's HTTP response returns immediately. The
+    collector handles missing-data and partial-fetch cases internally; the ML
+    retrain job updates ``ml_status`` to ``ready`` or ``failed`` on completion.
+
+    Skips entirely when ``hist_collector`` is not registered on ``app_state`` —
+    that indicates a non-production wiring (tests, partial bootstrap) where
+    running seed/retrain would race with the test's own assertions.
+
+    Claims the row by flipping ``ml_status`` to ``'training'`` *before* spending
+    minutes on the seed: avoids paying collector cost when an explicit
+    /retrain has already started for the same symbol.
+
+    Serialized through ``_BOOTSTRAP_SEMAPHORE`` so we do not pile up retrains.
+    """
+    from datetime import timedelta
+
+    collector = getattr(app_state, "hist_collector", None)
+    scheduler = getattr(app_state, "scheduler", None)
+    manager = getattr(app_state, "manager", None)
+
+    if collector is None or scheduler is None or manager is None:
+        return
+
+    async with _BOOTSTRAP_SEMAPHORE:
+        engine = manager.get_engine(symbol)
+        if engine is None:
+            return
+
+        async with async_session() as session:
+            result = await session.execute(
+                SymbolConfig.__table__.update()
+                .where(SymbolConfig.symbol == symbol, SymbolConfig.ml_status == "pending")
+                .values(ml_status="training", updated_at=datetime.utcnow(), updated_by="bootstrap")
+            )
+            await session.commit()
+        if result.rowcount == 0:
+            logger.info(f"Bootstrap [{symbol}] skipped — ml_status already advanced")
+            return
+
+        now = datetime.utcnow()
+        from_date = (now - timedelta(days=days)).strftime("%Y-%m-%d")
+        to_date = now.strftime("%Y-%m-%d")
+        try:
+            stats = await collector.collect(symbol, timeframe, from_date, to_date)
+            logger.info(f"Bootstrap seed [{symbol}]: {stats['new_bars_inserted']} new bars")
+        except Exception as e:
+            logger.warning(f"Bootstrap seed [{symbol}] failed: {e}")
+
+        try:
+            await scheduler._ml_retrain_symbol(symbol, engine)
+        except Exception as e:
+            logger.error(f"Bootstrap retrain [{symbol}] failed: {e}")
+
+
 _PATH_TO_CLASS: tuple[tuple[str, str], ...] = (
     ("cryptocurrenc", "crypto"),
     ("crypto", "crypto"),
@@ -304,6 +378,47 @@ async def get_symbol(symbol: str, db: AsyncSession = Depends(get_db)) -> SymbolR
     return SymbolResponse.model_validate(cfg)
 
 
+async def _validate_asset_class_against_broker(
+    request: Request,
+    broker_symbol: str,
+    declared: str,
+) -> None:
+    """Cross-check declared asset_class with broker's symbol path.
+
+    Raises 400 when the broker reports an unambiguous asset class that conflicts
+    with the user's choice (e.g. user picked ``forex`` for a crypto symbol).
+    Soft-fails when the broker is unreachable so symbol creation is not blocked
+    by transient bridge outages.
+    """
+    connector = getattr(request.app.state, "connector", None)
+    if connector is None:
+        return
+    try:
+        # Cap on bridge latency: validation runs on the API hot path so a
+        # slow bridge must not turn a symbol-create into a 30s wait.
+        spec = await asyncio.wait_for(connector.get_symbol_spec(broker_symbol), timeout=3.0)
+        if not isinstance(spec, dict) or not spec.get("success"):
+            return
+        data = spec.get("data")
+        if not isinstance(data, dict):
+            return
+        path = data.get("path") or ""
+    except Exception as e:
+        logger.debug(f"asset_class validate skipped [{broker_symbol}]: {e}")
+        return
+    if not path:
+        return
+    inferred = _infer_asset_class(path)
+    if inferred != declared:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"asset_class={declared!r} does not match broker path {path!r} "
+                f"(inferred {inferred!r}). Use {inferred!r} or pick a different symbol."
+            ),
+        )
+
+
 @router.post("", dependencies=[Depends(require_auth)])
 async def create_symbol(
     req: SymbolCreateRequest,
@@ -312,6 +427,8 @@ async def create_symbol(
 ) -> SymbolResponse:
     if await svc.get_config(db, req.symbol):
         raise HTTPException(status_code=409, detail=f"Symbol '{req.symbol}' already exists")
+
+    await _validate_asset_class_against_broker(request, req.broker_alias or req.symbol, req.asset_class)
 
     # Check for soft-deleted row with same symbol — revive it instead of INSERT
     # (DB has a unique constraint on `symbol`, so a raw INSERT would fail with
@@ -343,6 +460,16 @@ async def create_symbol(
     await db.refresh(cfg)
     await _publish(request, req.symbol, "created")
     await _reload_engines_direct(request)
+
+    # Kick off historical seed + ML retrain so the new symbol can produce
+    # signals on the next candle close instead of waiting for Monday's
+    # weekly retrain. Runs detached — API response returns immediately.
+    from app.bot.engine import _spawn_background
+
+    _spawn_background(
+        _bootstrap_new_symbol(request.app.state, req.symbol, req.ml_timeframe or req.default_timeframe),
+        name=f"symbol_bootstrap:{req.symbol}",
+    )
 
     logger.info(f"Symbol {action}: {req.symbol}")
     return SymbolResponse.model_validate(cfg)

--- a/backend/app/api/routes/webhooks.py
+++ b/backend/app/api/routes/webhooks.py
@@ -21,12 +21,17 @@ def init_webhooks(manager):
 
 
 class TradingViewAlert(BaseModel):
-    symbol: str
-    action: str  # "BUY" or "SELL"
+    symbol: str = Field(min_length=2, max_length=32, pattern=r"^[A-Za-z0-9._-]+$")
+    action: str = Field(pattern=r"^(?i:BUY|SELL)$")
     price: float | None = None
-    key: str  # webhook secret for validation
+    key: str = Field(min_length=8, max_length=256)
     timestamp: int | None = Field(None, description="Unix seconds — reject if older than WEBHOOK_MAX_AGE_SECONDS")
-    nonce: str | None = Field(None, description="Unique per-alert token — rejected on replay")
+    nonce: str | None = Field(
+        None,
+        max_length=64,
+        pattern=r"^[A-Za-z0-9_-]+$",
+        description="Unique per-alert token — rejected on replay",
+    )
 
 
 WEBHOOK_MAX_AGE_SECONDS = 60
@@ -43,19 +48,20 @@ async def tradingview_webhook(alert: TradingViewAlert, request: Request):
       timestamp — unix seconds, rejected if older than WEBHOOK_MAX_AGE_SECONDS
       nonce     — unique token, rejected on replay within _WEBHOOK_NONCE_TTL_SECONDS
     """
-    # Validate webhook key
+    # Validate webhook key. Fall back to the encrypted Secret row if no env var
+    # is set so operators can rotate the key via the UI without redeploying.
     expected_key = os.environ.get("TRADINGVIEW_WEBHOOK_KEY", "")
     if not expected_key:
-        # Try vault
         try:
-            from app.vault import VaultService
+            from app.db.session import async_session, get_secret_or_none
+            from app.vault import vault as vault_singleton
 
-            vault_key = os.environ.get("VAULT_MASTER_KEY", "")
-            if vault_key:
-                vault = VaultService(vault_key)
-                expected_key = await vault.get("tradingview_webhook_key") or ""
-        except Exception:
-            pass
+            async with async_session() as db:
+                secret = await get_secret_or_none(db, "tradingview_webhook_key")
+                if secret and secret.encrypted_value and secret.nonce:
+                    expected_key = vault_singleton.decrypt(secret.encrypted_value, secret.nonce) or ""
+        except Exception as e:
+            logger.warning(f"webhook secret lookup failed: {type(e).__name__}")
 
     if not expected_key:
         raise HTTPException(status_code=503, detail="TradingView webhook key not configured")

--- a/backend/app/audit.py
+++ b/backend/app/audit.py
@@ -1,5 +1,6 @@
 """Shared audit logging utility."""
 
+from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import AuditLog
@@ -20,6 +21,10 @@ async def log_audit(
     Args:
         auto_commit: If True (default), commits immediately.
                      Set False to let the caller commit as part of a larger transaction.
+
+    Failures are logged at ERROR (not silenced) so a broken audit pipeline shows
+    up in observability. Audit must be best-effort but never invisible — losing
+    an audit trail without alarm is itself a compliance event.
     """
     try:
         log = AuditLog(
@@ -33,8 +38,13 @@ async def log_audit(
         db.add(log)
         if auto_commit:
             await db.commit()
-    except Exception:
-        try:
-            await db.rollback()
-        except Exception:
-            pass
+    except Exception as e:
+        logger.error(f"audit_log_write_failed action={action!r} resource={resource!r}: {e!r}")
+        # Only roll back when we own the transaction. With auto_commit=False the
+        # caller is mid-transaction — a rollback here would discard their pending
+        # work. Caller's own except handler is responsible in that mode.
+        if auto_commit:
+            try:
+                await db.rollback()
+            except Exception as rb_err:
+                logger.error(f"audit_log_rollback_failed action={action!r}: {rb_err!r}")

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -19,17 +19,24 @@ _jwt_module = None
 _pwd_context = None
 
 
+JWT_ALGORITHM = "HS256"
+
+
 def _get_jwt():
+    """Lazy PyJWT loader. Migrated off python-jose 3.3.0 (CVE-2024-33663/33664
+    algorithm confusion). PyJWT is actively maintained and the same `decode`
+    call already pins ``algorithms=[JWT_ALGORITHM]`` so unsigned ``alg=none``
+    tokens are rejected at the library boundary."""
     global _jwt_module
     if _jwt_module is None:
         try:
-            from jose import jwt
+            import jwt as _jwt
 
-            _jwt_module = jwt
+            _jwt_module = _jwt
         except ImportError as e:
             raise HTTPException(
                 status_code=500,
-                detail="python-jose not installed. Run: pip install python-jose[cryptography]",
+                detail="PyJWT not installed. Run: pip install 'PyJWT[crypto]>=2.10.1'",
             ) from e
     return _jwt_module
 
@@ -60,15 +67,41 @@ def _assert_auth_consistent() -> None:
             "AUTH_PASSWORD_HASH is set but AUTH_USERNAME is empty — refusing to start. "
             "Either set both, or clear AUTH_PASSWORD_HASH to disable auth."
         )
-    # Empty SECRET_KEY produces trivially-forgeable JWTs: python-jose accepts
-    # an empty HMAC key. Refuse to start when any JWT-issuing path is live.
     if _auth_enabled() and not settings.secret_key:
         raise RuntimeError(
             "SECRET_KEY is empty while auth is enabled — refusing to start. Set SECRET_KEY to a long random value."
         )
-    _PLACEHOLDERS = {"change-me-in-production", "changeme", "secret", "please-change"}
-    if settings.secret_key.strip().lower() in _PLACEHOLDERS:
+    _PLACEHOLDERS = {
+        "change-me-in-production",
+        "changeme",
+        "secret",
+        "please-change",
+        "password",
+        "1234",
+        "test",
+        "default",
+    }
+    sk = settings.secret_key.strip()
+    if sk.lower() in _PLACEHOLDERS:
         raise RuntimeError("SECRET_KEY is set to a placeholder value — refusing to start. Generate a real secret.")
+    # 32 chars ≈ 192 bits when base64-ish, comfortably above the 128-bit
+    # collision floor for HMAC-SHA256. Refuse short keys that would let an
+    # offline attacker brute-force the JWT signing material.
+    if _auth_enabled() and len(sk) < 32:
+        raise RuntimeError(
+            "SECRET_KEY must be at least 32 characters when auth is enabled. "
+            "Generate via: python -c 'import secrets; print(secrets.token_urlsafe(48))'"
+        )
+    if settings.vault_master_key and len(settings.vault_master_key) < 32:
+        raise RuntimeError(
+            "VAULT_MASTER_KEY must be at least 32 characters. "
+            "Short keys reduce HKDF entropy and let an offline attacker brute-force the derived AES key."
+        )
+    if "*" in settings.cors_origin_list:
+        raise RuntimeError(
+            "CORS_ORIGINS must not contain '*' — wildcard origins combined with credentialed cookies "
+            "violate the CORS spec and expose the API to any origin. List exact origins instead."
+        )
 
 
 # ─── Models ───────────────────────────────────────────────────────────────────
@@ -92,25 +125,42 @@ def create_access_token(username: str, expire_hours: int | None = None) -> str:
     hours = expire_hours if expire_hours is not None else settings.jwt_expire_hours
     expire = datetime.now(UTC) + timedelta(hours=hours)
     payload = {"sub": username, "exp": expire}
-    return jwt.encode(payload, settings.secret_key, algorithm="HS256")
+    return jwt.encode(payload, settings.secret_key, algorithm=JWT_ALGORITHM)
 
 
 def mint_internal_token() -> str:
-    """Long-lived JWT (90 days) for internal MCP tools → backend API calls.
+    """Short-lived JWT (24h) for internal MCP tools → backend API calls.
+
+    Re-minted on every app restart, so a Railway redeploy invalidates the
+    previous token. Avoid 90-day tokens that linger in env vars / process
+    memory long after a leak window.
 
     Empty string when auth disabled.
     """
     if not _auth_enabled() or not settings.secret_key:
         return ""
-    return create_access_token("internal_agent", expire_hours=90 * 24)
+    return create_access_token("internal_agent", expire_hours=24)
 
 
 def verify_token(token: str) -> str | None:
     """Verify JWT and return username, or None if invalid."""
     jwt = _get_jwt()
     try:
-        payload = jwt.decode(token, settings.secret_key, algorithms=["HS256"])
+        payload = jwt.decode(token, settings.secret_key, algorithms=[JWT_ALGORITHM])
         return payload.get("sub")
+    except Exception:
+        return None
+
+
+def decode_token(token: str) -> dict | None:
+    """Decode a JWT and return the full payload (or None on failure).
+
+    Used by paths that need claims beyond ``sub`` — e.g. checking ``jti`` for
+    session revocation in /ws-token.
+    """
+    jwt = _get_jwt()
+    try:
+        return jwt.decode(token, settings.secret_key, algorithms=[JWT_ALGORITHM])
     except Exception:
         return None
 
@@ -157,16 +207,18 @@ async def login(req: LoginRequest, request: Request):
         raise HTTPException(status_code=500, detail="SECRET_KEY not configured — cannot sign tokens")
 
     pwd_context = _get_pwd_context()
-    # Strip newlines to blunt log injection via username field.
     safe_user = req.username.replace("\n", " ").replace("\r", " ")[:64]
     ip = request.client.host if request.client else "unknown"
 
-    if req.username != settings.auth_username:
-        logger.warning(f"login_failed user={safe_user!r} reason=unknown_user ip={ip}")
-        raise HTTPException(status_code=401, detail="Invalid credentials")
-
-    if not pwd_context.verify(req.password, settings.auth_password_hash):
-        logger.warning(f"login_failed user={safe_user!r} reason=bad_password ip={ip}")
+    # Always run bcrypt regardless of username match so an unknown username and
+    # a wrong password cost the attacker the same observable time. Otherwise a
+    # ~100ms gap leaks "username exists" and turns rate-limited brute-force into
+    # a tractable two-stage attack.
+    user_ok = req.username == settings.auth_username
+    pw_ok = pwd_context.verify(req.password, settings.auth_password_hash)
+    if not (user_ok and pw_ok):
+        reason = "unknown_user" if not user_ok else "bad_password"
+        logger.warning(f"login_failed user={safe_user!r} reason={reason} ip={ip}")
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
     token = create_access_token(req.username)
@@ -180,6 +232,9 @@ async def get_ws_token(request: Request):
 
     Reads the JWT from the httpOnly 'session' cookie (set by WebAuthn login)
     and returns a short-lived token the frontend can pass as a query param.
+    Verifies the JTI is still active in the AuthSession table — a logged-out
+    or revoked session must not be able to mint new WS tokens just because
+    the underlying JWT has not expired yet.
     """
     if not _auth_enabled():
         return {"token": "__noauth__"}
@@ -189,16 +244,38 @@ async def get_ws_token(request: Request):
     if not session_token:
         raise HTTPException(status_code=401, detail="No session cookie")
 
-    username = verify_token(session_token)
-    if not username:
+    payload = decode_token(session_token)
+    if not payload or not payload.get("sub"):
         raise HTTPException(status_code=401, detail="Invalid session")
 
-    # Short-lived token (30 seconds) for WS handshake only
+    jti = payload.get("jti")
+    if jti:
+        try:
+            from sqlalchemy import select
+
+            from app.db.models import AuthSession
+            from app.db.session import async_session
+
+            async with async_session() as db:
+                result = await db.execute(
+                    select(AuthSession.id).where(
+                        AuthSession.jwt_jti == jti,
+                        AuthSession.revoked_at.is_(None),
+                    )
+                )
+                if result.scalar_one_or_none() is None:
+                    raise HTTPException(status_code=401, detail="Session revoked")
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.warning(f"ws-token revocation check failed (deny by default): {e!r}")
+            raise HTTPException(status_code=503, detail="session_check_unavailable") from e
+
     expire = datetime.now(UTC) + timedelta(seconds=30)
     ws_token = jwt_mod.encode(
-        {"sub": username, "exp": expire, "purpose": "ws"},
+        {"sub": payload["sub"], "exp": expire, "purpose": "ws"},
         settings.secret_key,
-        algorithm="HS256",
+        algorithm=JWT_ALGORITHM,
     )
     return {"token": ws_token}
 

--- a/backend/app/auth_webauthn.py
+++ b/backend/app/auth_webauthn.py
@@ -64,7 +64,7 @@ ORIGIN = settings.webauthn_origin if hasattr(settings, "webauthn_origin") else "
 
 def _create_jwt(owner_id: int, jti: str) -> str:
     """Create a JWT token for session."""
-    from jose import jwt
+    import jwt
 
     expire = datetime.now(UTC) + timedelta(hours=settings.jwt_expire_hours)
     payload = {"sub": str(owner_id), "jti": jti, "exp": expire}
@@ -73,7 +73,7 @@ def _create_jwt(owner_id: int, jti: str) -> str:
 
 def _verify_jwt(token: str) -> dict | None:
     """Verify JWT and return payload."""
-    from jose import jwt
+    import jwt
 
     try:
         return jwt.decode(token, settings.secret_key, algorithms=["HS256"])
@@ -106,19 +106,48 @@ class RegisterOptionsRequest(BaseModel):
     display_name: str = "Admin"
 
 
+def _check_setup_token(req_header: str | None) -> None:
+    """Gate the first-time registration with a one-time setup token.
+
+    Without this, a fresh deployment that exposes /api/auth/register/options
+    publicly lets the first remote attacker register their own passkey before
+    the legitimate operator. Operator generates a random token and sets it as
+    ``WEBAUTHN_SETUP_TOKEN`` before deploy; deletes the env var after first
+    successful setup.
+
+    No-op once setup is complete (subsequent passkey adds use existing-session
+    auth at the network edge).
+    """
+    import os
+
+    expected = os.getenv("WEBAUTHN_SETUP_TOKEN", "")
+    if not expected:
+        raise HTTPException(
+            status_code=503,
+            detail="WebAuthn registration disabled. Set WEBAUTHN_SETUP_TOKEN env var to enable initial setup.",
+        )
+    if not req_header or not isinstance(req_header, str):
+        raise HTTPException(status_code=401, detail="Missing X-Setup-Token header")
+    import hmac as _hmac
+
+    if not _hmac.compare_digest(req_header, expected):
+        raise HTTPException(status_code=401, detail="Invalid setup token")
+
+
 @router.post("/register/options")
 async def register_options(req: RegisterOptionsRequest, request: Request, db: AsyncSession = Depends(get_db)):
-    """Generate WebAuthn registration challenge. Only works if setup not complete."""
+    """Generate WebAuthn registration challenge. First-time setup requires a
+    matching ``X-Setup-Token`` header so a public deployment cannot be hijacked
+    by whoever reaches /register/options first."""
     from webauthn import generate_registration_options
     from webauthn.helpers.structs import AuthenticatorSelectionCriteria, ResidentKeyRequirement
 
-    # Check if already set up
     result = await db.execute(select(Owner).limit(1))
     owner = result.scalar_one_or_none()
-    if owner and owner.is_setup_complete:
-        # Allow adding more passkeys if setup is complete (for backup devices)
-        pass
-    elif not owner:
+    if not owner or not owner.is_setup_complete:
+        _check_setup_token(request.headers.get("x-setup-token"))
+
+    if not owner:
         owner = Owner(display_name=req.display_name)
         db.add(owner)
         await db.commit()
@@ -178,7 +207,12 @@ async def register_verify(req: RegisterVerifyRequest, request: Request, db: Asyn
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Registration failed: {e}") from e
 
-    # Store credential
+    # Bound the bytes we accept from the authenticator. Any conformant client
+    # produces credential_id ≤ 256 bytes and public_key ≤ 1 KB; larger payloads
+    # are anomalous and a cheap DoS vector against the LargeBinary column.
+    if len(verification.credential_id) > 1024 or len(verification.credential_public_key) > 4096:
+        raise HTTPException(status_code=400, detail="Credential payload too large")
+
     new_cred = WebAuthnCredential(
         owner_id=req.owner_id,
         credential_id=verification.credential_id,
@@ -226,15 +260,20 @@ async def login_options(request: Request, db: AsyncSession = Depends(get_db)):
         allow_credentials=[PublicKeyCredentialDescriptor(id=c.credential_id) for c in creds],
     )
 
-    await _store_challenge(request, "login", options.challenge)
+    # Per-attempt challenge key prevents two concurrent /login/options calls
+    # from clobbering each other's challenge in Redis. Client must echo this
+    # back at /login/verify so we look up the matching challenge.
+    challenge_key = secrets.token_urlsafe(16)
+    await _store_challenge(request, f"login:{challenge_key}", options.challenge)
 
     from webauthn.helpers import options_to_json
 
-    return {"options": options_to_json(options)}
+    return {"options": options_to_json(options), "challenge_key": challenge_key}
 
 
 class LoginVerifyRequest(BaseModel):
     credential: dict
+    challenge_key: str
 
 
 @router.post("/login/verify")
@@ -247,7 +286,9 @@ async def login_verify(
     from webauthn import verify_authentication_response
     from webauthn.helpers import parse_authentication_credential_json
 
-    challenge = await _pop_challenge(request, "login")
+    if not req.challenge_key or len(req.challenge_key) > 64:
+        raise HTTPException(status_code=400, detail="Missing or invalid challenge_key")
+    challenge = await _pop_challenge(request, f"login:{req.challenge_key}")
     if not challenge:
         raise HTTPException(status_code=400, detail="Login challenge expired")
 

--- a/backend/app/backtest/engine.py
+++ b/backend/app/backtest/engine.py
@@ -138,8 +138,8 @@ class BacktestEngine:
                     else:
                         entry_price -= half_spread
                 sl_tp = self.risk_manager.calculate_sl_tp(entry_price, signal, atr)
-                sl_pips = abs(entry_price - sl_tp.sl)
-                lot = self.risk_manager.calculate_lot_size(balance, sl_pips)
+                sl_distance = abs(entry_price - sl_tp.sl)
+                lot = self.risk_manager.calculate_lot_size(balance, sl_distance)
 
                 open_trade = {
                     "type": "BUY" if signal == 1 else "SELL",

--- a/backend/app/bot/engine.py
+++ b/backend/app/bot/engine.py
@@ -1044,9 +1044,7 @@ class BotEngine:
             try:
                 await self.db.rollback()
             except Exception as rb_err:
-                logger.error(
-                    f"Streak adjustment rollback failed [{self.symbol}] — db session is dirty: {rb_err!r}"
-                )
+                logger.error(f"Streak adjustment rollback failed [{self.symbol}] — db session is dirty: {rb_err!r}")
         return lot
 
     def _create_paper_order(self, order_type: str, lot: float, entry_price: float, sl_tp, comment: str) -> dict:

--- a/backend/app/bot/engine.py
+++ b/backend/app/bot/engine.py
@@ -98,6 +98,33 @@ from app.strategy.base import BaseStrategy
 _UNSET = object()  # Sentinel for "parameter not passed" (distinct from None)
 
 
+# Default strategy per asset class — picked when a symbol's profile doesn't
+# override ``strategy_default``. Keep conservative, trend-following choices for
+# the original four symbols (ema_crossover) and lean to mean reversion / breakout
+# for asset classes whose price action favors them.
+_DEFAULT_STRATEGY_BY_ASSET_CLASS: dict[str, str] = {
+    "forex": "ema_crossover",
+    "metal": "ema_crossover",
+    "energy": "breakout",
+    "crypto": "breakout",
+    "index": "mean_reversion",
+    "stock": "momentum_rank",
+}
+
+
+def _resolve_default_strategy(profile: dict) -> str:
+    """Pick the strategy name for a freshly-built engine.
+
+    Order: explicit ``profile['strategy_default']`` → asset-class default →
+    ``ema_crossover`` (legacy fallback).
+    """
+    explicit = profile.get("strategy_default")
+    if isinstance(explicit, str) and explicit:
+        return explicit
+    asset_class = (profile.get("asset_class") or "").lower()
+    return _DEFAULT_STRATEGY_BY_ASSET_CLASS.get(asset_class, "ema_crossover")
+
+
 _BACKGROUND_TASKS: set[asyncio.Task] = set()
 
 
@@ -148,8 +175,19 @@ class BotEngine:
 
         self.circuit_breaker = CircuitBreaker(redis_client, self.symbol)
 
-        # Initialize with defaults — can be updated via API
-        self.strategy: BaseStrategy = get_strategy("ema_crossover", symbol=self.symbol)
+        # Initialize with defaults — can be updated via API. Strategy choice
+        # honors per-profile override and asset-class heuristics so a freshly
+        # added crypto/index/stock symbol doesn't start on an unsuitable
+        # forex-tuned default.
+        default_strategy = _resolve_default_strategy(profile)
+        try:
+            self.strategy: BaseStrategy = get_strategy(default_strategy, symbol=self.symbol)
+        except Exception as e:
+            logger.warning(
+                f"Default strategy {default_strategy!r} unavailable for {self.symbol} ({e}); "
+                f"falling back to ema_crossover"
+            )
+            self.strategy = get_strategy("ema_crossover", symbol=self.symbol)
         self.risk_manager = RiskManager(
             max_risk_per_trade=settings.max_risk_per_trade,
             max_daily_loss=settings.max_daily_loss,
@@ -161,6 +199,7 @@ class BotEngine:
             price_decimals=profile.get("price_decimals", 2),
             sl_atr_mult=profile.get("sl_atr_mult", 1.5),
             tp_atr_mult=profile.get("tp_atr_mult", 2.0),
+            contract_size=profile.get("contract_size", 100),
         )
         self.sentiment_analyzer: NewsSentimentAnalyzer | None = None
         self.context_builder = AIContextBuilder(db_session)
@@ -214,6 +253,7 @@ class BotEngine:
         rm.sl_atr_mult = profile.get("sl_atr_mult", rm.sl_atr_mult)
         rm.tp_atr_mult = profile.get("tp_atr_mult", rm.tp_atr_mult)
         rm.max_lot = profile.get("max_lot", rm.max_lot)
+        rm.contract_size = profile.get("contract_size", rm.contract_size)
 
     def set_sentiment_analyzer(self, analyzer: NewsSentimentAnalyzer):
         self.sentiment_analyzer = analyzer
@@ -250,8 +290,8 @@ class BotEngine:
             cached = await self.sentiment_analyzer.get_latest_sentiment(symbol=self.symbol)
             if cached and cached.label != "neutral":
                 self._last_sentiment = cached.to_dict()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Sentiment cache load skipped [{self.symbol}]: {e}")
 
         strategy_name = self.strategy.name if self.strategy else "ai_autonomous"
         await self._log_event(BotEventType.STARTED, f"Bot started ({strategy_name})")
@@ -408,7 +448,8 @@ class BotEngine:
                     _recent = _res_wr.scalars().all()
                 if len(_recent) >= 10:
                     recent_wr_pref = sum(1 for t in _recent if t.profit > 0) / len(_recent)
-            except Exception:
+            except Exception as _wr_err:
+                logger.warning(f"recent_wr prefetch failed [{self.symbol}] — using default threshold: {_wr_err}")
                 recent_wr_pref = None
 
             if not await self._check_trade_permission(
@@ -684,8 +725,8 @@ class BotEngine:
                 drawdown_pct=dd_pct,
             )
             self._last_effective_threshold = eff_threshold
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"Adaptive confidence calc failed [{self.symbol}] — using base threshold: {e}")
 
         can_trade, reason = self.risk_manager.can_open_trade(
             current_positions=len(positions),
@@ -803,14 +844,15 @@ class BotEngine:
             await self._log_event(BotEventType.SIGNAL_DETECTED, f"Regime: {old_regime} → {regime}")
 
         sl_tp = self.risk_manager.calculate_sl_tp(entry_price, signal, atr)
-        sl_pips = abs(entry_price - sl_tp.sl)
+        # Price-unit distance (NOT pips) — RiskManager.calculate_lot_size now
+        # multiplies by contract_size directly so this is what it expects.
+        sl_distance = abs(entry_price - sl_tp.sl)
 
-        # Position sizing: fixed lot or AI-calculated (Kelly/risk-based)
         if self.fixed_lot is not None:
             lot = round(min(self.fixed_lot, self.risk_manager.max_lot), 2)
             lot = max(lot, MIN_LOT)
         else:
-            lot = await self._calculate_position_size(balance, sl_pips, effective_vol_pct)
+            lot = await self._calculate_position_size(balance, sl_distance, effective_vol_pct)
             # Apply warmup ramp-in
             lot = self._apply_warmup(lot)
             # Apply consecutive loss streak reduction
@@ -1001,8 +1043,10 @@ class BotEngine:
             logger.warning(f"Streak adjustment failed [{self.symbol}]: {e!r}")
             try:
                 await self.db.rollback()
-            except Exception:
-                pass
+            except Exception as rb_err:
+                logger.error(
+                    f"Streak adjustment rollback failed [{self.symbol}] — db session is dirty: {rb_err!r}"
+                )
         return lot
 
     def _create_paper_order(self, order_type: str, lot: float, entry_price: float, sl_tp, comment: str) -> dict:
@@ -1290,8 +1334,8 @@ class BotEngine:
         except Exception as e:
             try:
                 await self.db.rollback()
-            except Exception:
-                pass
+            except Exception as rb_err:
+                logger.error(f"ML feedback rollback failed [{self.symbol}]: {rb_err!r}")
             logger.warning(f"ML feedback update failed: {e}")
 
     async def _sync_paper_positions(self) -> list[dict]:
@@ -1511,8 +1555,8 @@ class BotEngine:
                 logger.warning(f"Trade save attempt {attempt + 1}/{max_retries} failed: {e}")
                 try:
                     await self.db.rollback()
-                except Exception:
-                    pass
+                except Exception as rb_err:
+                    logger.error(f"Trade save rollback failed [{self.symbol}]: {rb_err!r}")
                 if attempt < max_retries - 1:
                     await _asyncio.sleep(2**attempt)
 
@@ -1539,8 +1583,11 @@ class BotEngine:
         except Exception as e:
             logger.error(f"Redis fallback also failed: {e}")
 
-    async def _calculate_position_size(self, balance: float, sl_pips: float, atr_pct: float) -> float:
-        """Use Kelly Criterion if >= 20 closed trades, otherwise fixed risk sizing."""
+    async def _calculate_position_size(self, balance: float, sl_distance: float, atr_pct: float) -> float:
+        """Use Kelly Criterion if >= 20 closed trades, otherwise fixed risk sizing.
+
+        ``sl_distance`` is price-unit distance, fed straight to RiskManager.
+        """
         try:
             from sqlalchemy import select
 
@@ -1563,7 +1610,7 @@ class BotEngine:
                 if win_rate >= KELLY_MIN_WIN_RATE and avg_win > 0 and avg_loss > 0:
                     lot = self.risk_manager.calculate_kelly_size(
                         balance,
-                        sl_pips,
+                        sl_distance,
                         win_rate,
                         avg_win,
                         avg_loss,
@@ -1573,7 +1620,7 @@ class BotEngine:
         except Exception as e:
             logger.warning(f"Kelly sizing failed, using fixed risk: {e}")
 
-        return self.risk_manager.calculate_lot_size(balance, sl_pips, atr_pct=atr_pct)
+        return self.risk_manager.calculate_lot_size(balance, sl_distance, atr_pct=atr_pct)
 
     async def update_strategy(self, name: str, params: dict | None = None):
         self.strategy = get_strategy(name, params, symbol=self.symbol)
@@ -1598,6 +1645,11 @@ class BotEngine:
         if paper_trade is not None:
             self.paper_trade = paper_trade
             logger.info(f"Paper trade mode: {'ON' if paper_trade else 'OFF'}")
+            # Persist per-engine override so reload_engines() re-applies it
+            # when the same symbol's profile changes (avoid silent revert to
+            # global ``settings.paper_trade``).
+            if self._manager is not None:
+                self._manager.set_paper_trade_override(self.symbol, paper_trade)
         if timeframe is not None:
             valid = ["M1", "M5", "M15", "M30", "H1", "H4", "D1"]
             if timeframe in valid:
@@ -1622,16 +1674,18 @@ class BotEngine:
             logger.info(f"Lot sizing: {'fixed ' + str(self.fixed_lot) if self.fixed_lot else 'auto (AI)'}")
 
     async def _log_event(self, event_type: BotEventType, message: str):
+        """Persist a bot event using an isolated session so concurrent
+        candle/sync/reconcile jobs don't corrupt the engine's shared session
+        (asyncpg refuses concurrent operations on the same connection)."""
+        from app.db.session import async_session as _async_session
+
         try:
-            event = BotEvent(event_type=event_type, message=message)
-            self.db.add(event)
-            await self.db.commit()
+            async with _async_session() as session:
+                event = BotEvent(event_type=event_type, message=message)
+                session.add(event)
+                await session.commit()
         except Exception as e:
-            logger.error(f"Failed to log event: {e}")
-            try:
-                await self.db.rollback()
-            except Exception:
-                pass
+            logger.error(f"Failed to log event [{self.symbol}] {event_type}: {e}")
 
     async def _log_order_audit(
         self,
@@ -1769,8 +1823,8 @@ class BotEngine:
                         logger.warning(f"Failed to adopt orphan {ticket}: {e}")
                         try:
                             await self.db.rollback()
-                        except Exception:
-                            pass
+                        except Exception as rb_err:
+                            logger.error(f"Adopt-orphan rollback failed [{self.symbol}]: {rb_err!r}")
 
                 if adopted:
                     tickets_str = ", ".join(str(t) for t in sorted(adopted))
@@ -1828,5 +1882,5 @@ class BotEngine:
             logger.error(f"Position reconciliation error [{self.symbol}]: {e}")
             try:
                 await self.db.rollback()
-            except Exception:
-                pass
+            except Exception as rb_err:
+                logger.error(f"Reconcile rollback failed [{self.symbol}]: {rb_err!r}")

--- a/backend/app/bot/manager.py
+++ b/backend/app/bot/manager.py
@@ -41,6 +41,14 @@ class BotManager:
         # Optional back-reference set by BotScheduler so reload_engines() can
         # re-register cron candle jobs for newly-added symbols.
         self._scheduler = None
+        # Cached per-process services that newly-added engines need so they
+        # reach feature parity with engines wired during lifespan startup.
+        self._macro_service = None
+        self._event_calendar = None
+        self._optimizer = None
+        # Per-engine paper_trade overrides so a symbol toggled paper via
+        # /api/bot/settings persists across hot-reloads of the same engine.
+        self._paper_trade_overrides: dict[str, bool] = {}
         # Prefer DB-sourced enable flags; fall back to env-var symbol list when empty.
         db_enabled = [s for s, p in SYMBOL_PROFILES.items() if p.get("is_enabled") is True and "canonical" not in p]
         initial = db_enabled or settings.symbol_list
@@ -75,17 +83,51 @@ class BotManager:
 
     def set_scheduler(self, scheduler) -> None:
         self._scheduler = scheduler
+        for engine in self.engines.values():
+            engine._scheduler = scheduler
+
+    def set_macro_service(self, macro_service) -> None:
+        self._macro_service = macro_service
+        for engine in self.engines.values():
+            engine._macro_service = macro_service
+            engine.context_builder.set_macro_service(macro_service)
+
+    def set_event_calendar(self, event_calendar) -> None:
+        self._event_calendar = event_calendar
+        for engine in self.engines.values():
+            engine.context_builder.set_event_calendar(event_calendar)
+
+    def set_optimizer(self, optimizer) -> None:
+        self._optimizer = optimizer
+        for engine in self.engines.values():
+            engine._optimizer = optimizer
+
+    def set_paper_trade_override(self, symbol: str, paper_trade: bool | None) -> None:
+        """Persist a per-engine paper_trade flag so reload_engines re-applies it.
+
+        ``None`` clears the override (engine reverts to global ``settings.paper_trade``).
+        """
+        if paper_trade is None:
+            self._paper_trade_overrides.pop(symbol, None)
+        else:
+            self._paper_trade_overrides[symbol] = paper_trade
 
     async def start(self, symbol: str | None = None):
-        """Start one or all engines."""
+        """Start one or all engines. Failures are logged per-engine and do not
+        abort the rest (gather without return_exceptions cancels siblings on
+        first error — broker hiccups must not knock out healthy engines)."""
         if symbol:
             engine = self.engines.get(symbol)
             if engine:
                 await engine.start()
             else:
                 logger.warning(f"BotManager: unknown symbol {symbol}")
-        else:
-            await asyncio.gather(*(e.start() for e in self.engines.values()))
+            return
+        engines = list(self.engines.items())
+        results = await asyncio.gather(*(e.start() for _, e in engines), return_exceptions=True)
+        for (sym, _), result in zip(engines, results, strict=True):
+            if isinstance(result, Exception):
+                logger.error(f"BotManager.start [{sym}] failed: {result!r}")
 
     async def stop(self, symbol: str | None = None):
         """Stop one or all engines."""
@@ -93,8 +135,12 @@ class BotManager:
             engine = self.engines.get(symbol)
             if engine:
                 await engine.stop()
-        else:
-            await asyncio.gather(*(e.stop() for e in self.engines.values()))
+            return
+        engines = list(self.engines.items())
+        results = await asyncio.gather(*(e.stop() for _, e in engines), return_exceptions=True)
+        for (sym, _), result in zip(engines, results, strict=True):
+            if isinstance(result, Exception):
+                logger.warning(f"BotManager.stop [{sym}] failed: {result!r}")
 
     async def emergency_stop(self, symbol: str | None = None) -> dict:
         """Emergency stop — close all positions for one or all symbols."""
@@ -195,6 +241,17 @@ class BotManager:
             engine.set_sentiment_analyzer(self._sentiment_analyzer)
         if self._notifier:
             engine.set_notifier(self._notifier)
+        if self._macro_service:
+            engine._macro_service = self._macro_service
+            engine.context_builder.set_macro_service(self._macro_service)
+        if self._event_calendar is not None:
+            engine.context_builder.set_event_calendar(self._event_calendar)
+        if self._optimizer is not None:
+            engine._optimizer = self._optimizer
+        if self._scheduler is not None:
+            engine._scheduler = self._scheduler
+        if symbol in self._paper_trade_overrides:
+            engine.paper_trade = self._paper_trade_overrides[symbol]
         return engine
 
     async def reload_engines(self) -> dict:
@@ -202,7 +259,14 @@ class BotManager:
 
         Serialized by _engines_lock so concurrent pubsub + direct reload calls
         cannot produce partial dict state visible to iterating scheduler jobs.
+
+        Newly added engines auto-start when any pre-existing engine was RUNNING,
+        so toggling a symbol on at /symbols starts trading without a separate
+        /api/bot/start call. Auto-start runs *inside* the lock to prevent a
+        concurrent reload from popping the engine before its start() completes.
         """
+        from app.bot.engine import BotState
+
         async with self._engines_lock:
             enabled = {s for s, p in SYMBOL_PROFILES.items() if p.get("is_enabled") is True and "canonical" not in p}
             if not enabled:
@@ -213,13 +277,18 @@ class BotManager:
             to_remove = current - enabled
             to_update = enabled & current
 
+            was_active = any(e.state in (BotState.RUNNING, BotState.PAUSED) for e in self.engines.values())
+
             stop_coros = [self.engines.pop(s).stop() for s in to_remove]
             if stop_coros:
                 await asyncio.gather(*stop_coros, return_exceptions=True)
 
+            new_engines: list[BotEngine] = []
             for symbol in to_add:
                 try:
-                    self.engines[symbol] = self._build_engine(symbol, SYMBOL_PROFILES.get(symbol, {}))
+                    engine = self._build_engine(symbol, SYMBOL_PROFILES.get(symbol, {}))
+                    self.engines[symbol] = engine
+                    new_engines.append(engine)
                 except Exception as e:
                     logger.error(f"BotManager: create {symbol} failed: {e}")
 
@@ -228,11 +297,24 @@ class BotManager:
                 if profile:
                     self.engines[symbol].apply_profile(profile)
 
+            started: list[str] = []
+            if was_active and new_engines:
+                start_results = await asyncio.gather(
+                    *(e.start() for e in new_engines),
+                    return_exceptions=True,
+                )
+                for engine, result in zip(new_engines, start_results, strict=True):
+                    if isinstance(result, Exception):
+                        logger.warning(f"BotManager: auto-start {engine.symbol} failed: {result}")
+                    else:
+                        started.append(engine.symbol)
+
             summary = {
                 "added": sorted(to_add),
                 "removed": sorted(to_remove),
                 "updated": sorted(to_update),
                 "active": sorted(self.engines.keys()),
+                "auto_started": sorted(started),
             }
 
         if self._scheduler is not None and (to_add or to_remove):

--- a/backend/app/bot/scheduler.py
+++ b/backend/app/bot/scheduler.py
@@ -125,15 +125,19 @@ class BotScheduler:
             max_instances=1,
         )
 
-        # Daily reset: midnight UTC
-        self.scheduler.add_job(
-            self._daily_reset_job,
-            "cron",
-            hour=0,
-            minute=0,
-            id="daily_reset",
-            max_instances=1,
-        )
+        # Daily reset — schedule one job per unique reset_hour across asset
+        # classes so a USDJPY symbol's daily window does not span 26 hours
+        # because its market closes at 22 UTC but we reset at 00 UTC.
+        for reset_hour in self._unique_reset_hours():
+            self.scheduler.add_job(
+                self._daily_reset_for_hour,
+                "cron",
+                hour=reset_hour,
+                minute=0,
+                id=f"daily_reset_h{reset_hour:02d}",
+                max_instances=1,
+                args=[reset_hour],
+            )
 
         # Weekly ML retrain: Monday 04:00 UTC (before market open, after macro collect)
         self.scheduler.add_job(
@@ -217,6 +221,17 @@ class BotScheduler:
             max_instances=1,
         )
 
+        # Daily DB backup: 02:30 UTC. Skips when backups are not configured (no
+        # ENABLE_DB_BACKUPS=1) so dev environments do not pile up dumps.
+        self.scheduler.add_job(
+            self._db_backup_job,
+            "cron",
+            hour=2,
+            minute=30,
+            id="db_backup",
+            max_instances=1,
+        )
+
         # Economic calendar refresh every hour
         self.scheduler.add_job(
             self._refresh_economic_calendar,
@@ -250,8 +265,12 @@ class BotScheduler:
         for job_id in self._candle_job_ids.values():
             try:
                 self.scheduler.remove_job(job_id)
-            except Exception:
-                pass
+            except Exception as e:
+                # JobLookupError is expected when a job has already been removed
+                # by a parallel reschedule; log anything else so a stuck job
+                # surfaces instead of letting the next add_job collide.
+                if e.__class__.__name__ != "JobLookupError":
+                    logger.warning(f"remove_job({job_id}) failed: {e!r}")
         self._candle_job_ids.clear()
 
         # Group engines by timeframe
@@ -301,6 +320,20 @@ class BotScheduler:
         task.add_done_callback(self._background_tasks.discard)
         return task
 
+    @staticmethod
+    def _log_gather_errors(job_name: str, results, labels: list | None = None) -> None:
+        """Surface exceptions returned by ``asyncio.gather(return_exceptions=True)``.
+
+        Without this, individual symbol/task failures are silently swallowed —
+        the gather succeeds even though half the work raised. Pair the result
+        list with optional labels (e.g. symbols) so log messages identify which
+        item failed.
+        """
+        for idx, result in enumerate(results):
+            if isinstance(result, Exception):
+                label = labels[idx] if labels and idx < len(labels) else f"task[{idx}]"
+                logger.warning(f"{job_name} {label} raised: {result!r}")
+
     def _engines_snapshot(self) -> dict[str, BotEngine]:
         """Return a stable snapshot for iteration independent of reload_engines."""
         if self.manager:
@@ -308,10 +341,12 @@ class BotScheduler:
         return dict(self._engines)
 
     async def _tick_job(self):
-        # Fetch ticks for ALL symbols (even STOPPED) so dashboard shows prices
-        tasks = [self._fetch_tick(sym, eng) for sym, eng in self._engines_snapshot().items()]
+        snapshot = self._engines_snapshot()
+        symbols = list(snapshot.keys())
+        tasks = [self._fetch_tick(sym, eng) for sym, eng in snapshot.items()]
         if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            self._log_gather_errors("tick_job", results, symbols)
 
     async def _fetch_tick(self, symbol: str, engine: BotEngine):
         try:
@@ -339,7 +374,7 @@ class BotScheduler:
                     else:
                         logger.warning(f"Invalid trading_mode in Redis: '{cached}', ignoring")
         except Exception as e:
-            logger.debug(f"Redis trading_mode read failed: {e}")
+            logger.warning(f"Redis trading_mode read failed (using fallback {trading_mode!r}): {e}")
 
         # Filter to symbols with open markets
         active_symbols = [sym for sym in symbols if is_market_open(sym)]
@@ -366,7 +401,7 @@ class BotScheduler:
                     try:
                         await engine._detect_regime()
                     except Exception as e:
-                        logger.debug(f"Regime detection [{sym}]: {e}")
+                        logger.warning(f"Regime detection failed [{sym}] — risk profile may be stale: {e}")
             await self._run_ai_agent(active_symbols)
 
     async def _sentiment_job(self):
@@ -459,7 +494,7 @@ class BotScheduler:
                             f"AI hallucination [{sym}]: {hc['high_severity_count']} high-severity flags: {hc['flags']}"
                         )
                 except Exception as e:
-                    logger.debug(f"Hallucination check failed [{sym}]: {e}")
+                    logger.warning(f"Hallucination check failed [{sym}] — AI claims unverified: {e}")
 
                 # Log AI analysis to DB for activity page
                 from app.db.models import BotEventType
@@ -483,12 +518,16 @@ class BotScheduler:
             except Exception as e:
                 logger.warning(f"AI agent [{sym}] error: {e}")
 
-        await asyncio.gather(*[_run_for_symbol(sym) for sym in symbols], return_exceptions=True)
+        results = await asyncio.gather(*[_run_for_symbol(sym) for sym in symbols], return_exceptions=True)
+        self._log_gather_errors("run_ai_agent", results, symbols)
 
     async def _sync_job(self):
-        tasks = [e.sync_positions() for e in self._engines_snapshot().values() if e.state.value == "RUNNING"]
+        snapshot = self._engines_snapshot()
+        symbols = [s for s, e in snapshot.items() if e.state.value == "RUNNING"]
+        tasks = [snapshot[s].sync_positions() for s in symbols]
         if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            self._log_gather_errors("sync_job", results, symbols)
 
     async def _weekly_optimize_job(self):
         logger.info("Weekly optimization triggered")
@@ -557,26 +596,108 @@ class BotScheduler:
             except Exception as e:
                 logger.warning(f"Economic calendar refresh failed: {e}")
 
-    async def _daily_reset_job(self):
-        logger.info("Daily reset triggered")
-        tasks = [e.circuit_breaker.reset() for e in self._engines_snapshot().values()]
-        await asyncio.gather(*tasks, return_exceptions=True)
+    def _unique_reset_hours(self) -> list[int]:
+        """Reset hours used across the asset classes we have engines for.
+
+        Falls back to ``[0]`` when called before any engine is built (e.g. during
+        scheduler.start() if no symbols enabled yet) so the daily reset still
+        fires at midnight UTC.
+        """
+        from app.market.sessions import _RULES
+
+        snapshot = self._engines_snapshot()
+        if not snapshot:
+            return [0]
+        hours = set()
+        for engine in snapshot.values():
+            asset_class = (engine.symbol_profile or {}).get("asset_class") or "forex"
+            rule = _RULES.get(asset_class.lower(), _RULES["forex"])
+            hours.add(rule["reset_hour_utc"])
+        return sorted(hours) or [0]
+
+    async def _daily_reset_for_hour(self, reset_hour: int):
+        """Reset circuit breakers only for engines whose asset class resets at
+        this hour. Per-asset-class resets keep daily P&L windows = 24 hours."""
+        from app.market.sessions import _RULES
+
+        snapshot = self._engines_snapshot()
+        symbols = []
+        for sym, eng in snapshot.items():
+            asset_class = (eng.symbol_profile or {}).get("asset_class") or "forex"
+            rule = _RULES.get(asset_class.lower(), _RULES["forex"])
+            if rule["reset_hour_utc"] == reset_hour:
+                symbols.append(sym)
+        if not symbols:
+            return
+        logger.info(f"Daily reset h{reset_hour:02d}UTC for {symbols}")
+        tasks = [snapshot[s].circuit_breaker.reset() for s in symbols]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        self._log_gather_errors(f"daily_reset_h{reset_hour:02d}", results, symbols)
+
+    async def _db_backup_job(self):
+        """Run scripts/backup_db.sh as a subprocess and surface its exit code.
+
+        Gated on ``ENABLE_DB_BACKUPS=1`` so dev / CI environments do not write
+        backup files. The script handles rotation; we only orchestrate the run.
+        """
+        import os
+        import shutil
+
+        if os.getenv("ENABLE_DB_BACKUPS", "0") != "1":
+            return
+        script = shutil.which("backup_db.sh") or "/app/scripts/backup_db.sh"
+        if not os.path.exists(script):
+            logger.warning(f"db_backup_job skipped: script not found at {script}")
+            return
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "bash",
+                script,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await proc.communicate()
+            if proc.returncode != 0:
+                logger.error(
+                    f"db_backup_job failed rc={proc.returncode} stderr={stderr.decode(errors='replace')[:500]}"
+                )
+            else:
+                logger.info(f"db_backup_job ok: {stdout.decode(errors='replace').splitlines()[-1] if stdout else ''}")
+        except Exception as e:
+            logger.error(f"db_backup_job exception: {e!r}")
 
     async def _ai_usage_cleanup_job(self):
-        """Delete AIUsageLog rows older than 90 days."""
+        """Delete AIUsageLog rows older than 90 days, batched 1000 per round
+        with a short sleep between. Avoids the ACCESS EXCLUSIVE lock spike that
+        a single multi-million-row DELETE would cause once the table is large.
+        """
         try:
             from datetime import timedelta
 
-            from sqlalchemy import delete
+            from sqlalchemy import text
 
-            from app.db.models import AIUsageLog
             from app.db.session import async_session
 
             cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=90)
-            async with async_session() as db:
-                result = await db.execute(delete(AIUsageLog).where(AIUsageLog.timestamp < cutoff))
-                await db.commit()
-                logger.info(f"AI usage cleanup: deleted {result.rowcount} rows older than 90d")
+            batch_size = 1000
+            total_deleted = 0
+            for _ in range(200):
+                async with async_session() as db:
+                    result = await db.execute(
+                        text(
+                            "DELETE FROM ai_usage_logs WHERE id IN ("
+                            "SELECT id FROM ai_usage_logs WHERE timestamp < :cutoff LIMIT :n"
+                            ")"
+                        ),
+                        {"cutoff": cutoff, "n": batch_size},
+                    )
+                    await db.commit()
+                deleted = result.rowcount or 0
+                total_deleted += deleted
+                if deleted < batch_size:
+                    break
+                await asyncio.sleep(0.5)
+            logger.info(f"AI usage cleanup: deleted {total_deleted} rows older than 90d")
         except Exception as e:
             logger.error(f"AI usage cleanup failed: {e}")
 
@@ -674,18 +795,22 @@ class BotScheduler:
             await self._health_monitor.check()
 
     async def _pending_trades_recovery_job(self):
-        tasks = [e._recover_pending_trades() for e in self._engines_snapshot().values()]
+        snapshot = self._engines_snapshot()
+        symbols = list(snapshot.keys())
+        tasks = [snapshot[s]._recover_pending_trades() for s in symbols]
         if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            self._log_gather_errors("pending_trades_recovery", results, symbols)
 
     async def _reconciliation_job(self):
-        tasks = [
-            e.reconcile_positions()
-            for e in self._engines_snapshot().values()
-            if e.state.value in ("RUNNING", "PAUSED") and not e.paper_trade
+        snapshot = self._engines_snapshot()
+        symbols = [
+            s for s, e in snapshot.items() if e.state.value in ("RUNNING", "PAUSED") and not e.paper_trade
         ]
+        tasks = [snapshot[s].reconcile_positions() for s in symbols]
         if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            self._log_gather_errors("reconciliation", results, symbols)
 
     async def _memory_consolidation_job(self):
         """Daily memory consolidation — promote, expire, decay memories."""
@@ -747,8 +872,13 @@ class BotScheduler:
 
             # Phase 1: short session — read current accuracy + load training data, then release.
             async with async_session() as session:
+                from sqlalchemy.orm import defer
+
                 result = await session.execute(
-                    select(MLModelLog).where(MLModelLog.is_active, MLModelLog.model_name == model_name).limit(1)
+                    select(MLModelLog)
+                    .where(MLModelLog.is_active, MLModelLog.model_name == model_name)
+                    .options(defer(MLModelLog.model_binary))
+                    .limit(1)
                 )
                 current_log = result.scalar_one_or_none()
                 current_accuracy = 0.0
@@ -848,6 +978,8 @@ class BotScheduler:
                         .where(MLModelLog.is_active, MLModelLog.model_name == model_name)
                         .values(is_active=False)
                     )
+                    from app.ml.integrity import compute_model_digest
+
                     log = MLModelLog(
                         model_name=model_name,
                         timeframe=engine.timeframe,
@@ -859,6 +991,7 @@ class BotScheduler:
                         feature_importance=json.dumps(new_result.feature_importance),
                         model_path=model_path,
                         model_binary=model_bytes,
+                        model_digest=compute_model_digest(model_bytes),
                         is_active=True,
                     )
                     session.add(log)
@@ -874,8 +1007,8 @@ class BotScheduler:
             if hasattr(engine, "notifier") and engine.notifier:
                 try:
                     await engine.notifier.send_message(msg)
-                except Exception:
-                    pass
+                except Exception as notif_err:
+                    logger.warning(f"ML retrain notify [{symbol}] failed: {notif_err!r}")
 
             await self._set_symbol_ml_status(symbol, "ready", mark_trained=True)
 

--- a/backend/app/bot/scheduler.py
+++ b/backend/app/bot/scheduler.py
@@ -804,9 +804,7 @@ class BotScheduler:
 
     async def _reconciliation_job(self):
         snapshot = self._engines_snapshot()
-        symbols = [
-            s for s, e in snapshot.items() if e.state.value in ("RUNNING", "PAUSED") and not e.paper_trade
-        ]
+        symbols = [s for s, e in snapshot.items() if e.state.value in ("RUNNING", "PAUSED") and not e.paper_trade]
         tasks = [snapshot[s].reconcile_positions() for s in symbols]
         if tasks:
             results = await asyncio.gather(*tasks, return_exceptions=True)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -177,7 +177,11 @@ class Settings(BaseSettings):
     # Redis
     redis_url: str = "redis://localhost:6379/0"
 
-    # AI (Claude Agent SDK uses CLAUDE_CODE_OAUTH_TOKEN env var directly)
+    # AI (Claude Agent SDK uses CLAUDE_CODE_OAUTH_TOKEN env var directly).
+    # Declared but unused: kept so older deployments with ANTHROPIC_API_KEY in
+    # their .env do not fail Settings validation under strict ``extra=forbid``.
+    # Actual API client is built around the SDK's OAuth flow.
+    anthropic_api_key: str = ""
 
     # Binance (for BTCUSD — uses Binance API instead of MT5)
     binance_api_key: str = ""
@@ -280,6 +284,12 @@ class Settings(BaseSettings):
     secret_key: str = ""
     cors_origins: str = "http://localhost:3000"
 
+    # Error reporting (Sentry). Empty DSN disables the integration entirely so
+    # dev / CI environments do not ship breadcrumbs.
+    sentry_dsn: str = ""
+    sentry_environment: str = "production"
+    sentry_traces_sample_rate: float = 0.05
+
     @property
     def symbol_list(self) -> list[str]:
         return [s.strip() for s in self.symbols.split(",") if s.strip()]
@@ -288,9 +298,21 @@ class Settings(BaseSettings):
     def cors_origin_list(self) -> list[str]:
         return [o.strip() for o in self.cors_origins.split(",")]
 
-    # DB connection pool
-    db_pool_size: int = 20
-    db_max_overflow: int = 30
+    # Trusted Host header allowlist. Empty = allow all (dev). Set in prod to
+    # block Host header injection / cache poisoning via spoofed forwarded
+    # hosts. Comma-separated, e.g. "myapp.up.railway.app,localhost".
+    trusted_hosts: str = ""
+
+    @property
+    def trusted_host_list(self) -> list[str]:
+        return [h.strip() for h in self.trusted_hosts.split(",") if h.strip()]
+
+    # DB connection pool — sized for Railway Postgres Hobby (25-conn cap).
+    # Total max (pool_size + max_overflow) must stay under the plan's
+    # connection limit minus headroom for migrations / background tools.
+    # Override via env on Pro plans where the cap is higher.
+    db_pool_size: int = 8
+    db_max_overflow: int = 12
     db_pool_timeout: int = 10
     db_pool_recycle: int = 1800
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -189,6 +189,10 @@ class MLModelLog(Base):
     feature_importance: Mapped[str] = mapped_column(Text)  # JSON
     model_path: Mapped[str] = mapped_column(String(255))
     model_binary: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    # HMAC-SHA256 of ``model_binary`` signed with SECRET_KEY at save time.
+    # Verified before joblib.load() so a tampered DB row cannot trigger pickle
+    # RCE when the strategy / scheduler reloads the model.
+    model_digest: Mapped[str | None] = mapped_column(String(64), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,3 +1,7 @@
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.config import settings
@@ -33,3 +37,64 @@ async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit
 async def get_db():
     async with async_session() as session:
         yield session
+
+
+@asynccontextmanager
+async def transaction(*, auto_commit: bool = True) -> AsyncIterator[AsyncSession]:
+    """Open an isolated session, commit on success, roll back on error.
+
+    Replaces the repeated ``async with async_session() as session: ... commit/rollback``
+    boilerplate. ``auto_commit=False`` lets the caller stage work and commit
+    explicitly while still getting rollback-on-exception.
+    """
+    async with async_session() as session:
+        try:
+            yield session
+            if auto_commit:
+                await session.commit()
+        except Exception:
+            await safe_rollback(session, "transaction")
+            raise
+
+
+async def safe_rollback(session: AsyncSession, context: str) -> None:
+    """Best-effort rollback that surfaces failures instead of swallowing them.
+
+    Used at fallback paths where a primary operation already failed; if the
+    rollback itself raises, observability matters more than re-raising over the
+    original error.
+    """
+    try:
+        await session.rollback()
+    except Exception as rb_err:
+        logger.error(f"rollback_failed context={context!r}: {rb_err!r}")
+
+
+async def get_secret_or_none(session: AsyncSession, key: str):
+    """Lookup an active Secret row by key. Returns None when missing.
+
+    Centralizes the ``WHERE key=? AND is_deleted=false`` filter so callers can
+    not accidentally match a soft-deleted row (the bug that pushed a stale
+    webhook key into the validator).
+    """
+    from sqlalchemy import select
+
+    from app.db.models import Secret
+
+    result = await session.execute(
+        select(Secret).where(Secret.key == key, Secret.is_deleted.is_(False))
+    )
+    return result.scalar_one_or_none()
+
+
+def defer_model_binary():
+    """Defer the LargeBinary ``MLModelLog.model_binary`` blob.
+
+    Used by metadata-only reads (status, drift, list) so a 10–50 MB model
+    payload is not loaded just to read accuracy / created_at fields.
+    """
+    from sqlalchemy.orm import defer
+
+    from app.db.models import MLModelLog
+
+    return defer(MLModelLog.model_binary)

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -81,9 +81,7 @@ async def get_secret_or_none(session: AsyncSession, key: str):
 
     from app.db.models import Secret
 
-    result = await session.execute(
-        select(Secret).where(Secret.key == key, Secret.is_deleted.is_(False))
-    )
+    result = await session.execute(select(Secret).where(Secret.key == key, Secret.is_deleted.is_(False)))
     return result.scalar_one_or_none()
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,7 @@ import os
 from contextlib import asynccontextmanager
 
 import redis.asyncio as redis_lib
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from loguru import logger
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -48,6 +48,7 @@ from app.api.routes import (
 )
 from app.api.websocket import router as ws_router
 from app.api.ws_runners import router as ws_runners_router
+from app.auth import require_auth
 from app.auth import router as auth_router
 from app.auth_webauthn import router as webauthn_router
 from app.bot.manager import BotManager
@@ -69,6 +70,35 @@ from app.db.session import engine as db_engine
 from app.health import check_health
 from app.mt5.connector import MT5BridgeConnector
 from app.notifications.telegram import TelegramNotifier
+
+
+def _init_sentry() -> None:
+    """Wire Sentry when ``SENTRY_DSN`` is set. Skipped silently otherwise.
+
+    Initialized at import time (before FastAPI app construction) so the SDK can
+    capture errors that happen during module import / lifespan setup, not only
+    request handlers.
+    """
+    if not settings.sentry_dsn:
+        return
+    try:
+        import sentry_sdk
+        from sentry_sdk.integrations.fastapi import FastApiIntegration
+        from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+
+        sentry_sdk.init(
+            dsn=settings.sentry_dsn,
+            environment=settings.sentry_environment,
+            traces_sample_rate=settings.sentry_traces_sample_rate,
+            send_default_pii=False,
+            integrations=[FastApiIntegration(), SqlalchemyIntegration()],
+        )
+        logger.info(f"Sentry initialized (env={settings.sentry_environment!r})")
+    except Exception as e:
+        logger.warning(f"Sentry init failed: {e!r}")
+
+
+_init_sentry()
 
 
 @asynccontextmanager
@@ -168,19 +198,17 @@ async def lifespan(app: FastAPI):
     first_engine = next(iter(manager.engines.values()))
     hist_collector = HistoricalDataCollector(first_engine.market_data, db_session)
 
-    # Initialize macro data service
+    # Initialize macro data service — register with BotManager so newly-added
+    # engines (via /api/symbols hot-reload) receive the same wiring.
     macro_service = MacroDataService(db_session)
     event_calendar = MacroEventCalendar()
-    for engine in manager.engines.values():
-        engine._macro_service = macro_service
-        engine.context_builder.set_macro_service(macro_service)
-        engine.context_builder.set_event_calendar(event_calendar)
+    manager.set_macro_service(macro_service)
+    manager.set_event_calendar(event_calendar)
 
     # Initialize optimizer (uses Claude Agent SDK via AIClient)
     optimizer = StrategyOptimizer(ai_client, db_session)
     optimizer.set_collector(hist_collector)
-    for engine in manager.engines.values():
-        engine._optimizer = optimizer
+    manager.set_optimizer(optimizer)
 
     # Initialize Telegram notifier
     notifier = TelegramNotifier()
@@ -204,6 +232,7 @@ async def lifespan(app: FastAPI):
     app.state.connector = connector
     app.state.redis = redis_client
     app.state.ai_client = ai_client
+    app.state.hist_collector = hist_collector
 
     # Initialize metrics
     from app.metrics import Metrics, set_metrics
@@ -257,7 +286,8 @@ async def lifespan(app: FastAPI):
     )
     app.state.pool_monitor = pool_monitor
 
-    # Start scheduler
+    # Start scheduler — BotScheduler.__init__ calls manager.set_scheduler(self),
+    # which propagates the back-reference to every engine including future ones.
     scheduler = BotScheduler(manager)
     scheduler.set_health_monitor(health_monitor)
     scheduler.start()
@@ -268,8 +298,6 @@ async def lifespan(app: FastAPI):
         id="db_pool_pressure",
         replace_existing=True,
     )
-    for engine in manager.engines.values():
-        engine._scheduler = scheduler
     app.state.scheduler = scheduler
 
     if macro_service.is_configured:
@@ -322,6 +350,21 @@ async def lifespan(app: FastAPI):
     symbols = manager.get_symbols()
     logger.info(f"Trading Bot initialized — symbols: {symbols}")
 
+    # Loud startup banner for safety-critical config so an operator skimming
+    # logs after a deploy can spot dangerous combinations at a glance.
+    if settings.paper_trade:
+        logger.warning("PAPER TRADE MODE — orders are simulated; no broker calls will hit MT5")
+    else:
+        logger.warning(f"LIVE TRADE MODE — rollout={settings.rollout_mode!r}; orders will hit broker")
+    if not (settings.telegram_bot_token and settings.telegram_chat_id):
+        logger.warning("Telegram alerts DISABLED — set TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID to enable")
+    if not settings.fred_api_key:
+        logger.info("FRED macro data DISABLED — set FRED_API_KEY for macro features")
+    if not settings.trusted_host_list:
+        logger.warning("TRUSTED_HOSTS not set — Host header validation disabled (set in production)")
+    if not settings.auth_password_hash:
+        logger.warning("AUTH_PASSWORD_HASH empty — API auth DISABLED (do not run in production)")
+
     yield
 
     # Shutdown
@@ -363,10 +406,14 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
         response.headers["Permissions-Policy"] = "geolocation=(), microphone=(), camera=()"
+        # CSP: API serves JSON in prod (docs gated by ENABLE_API_DOCS). Drop
+        # both script + style 'unsafe-inline'. If a future endpoint serves an
+        # HTML error page that needs inline style, switch that endpoint to
+        # JSON or use a per-response nonce instead of broadening CSP again.
         response.headers["Content-Security-Policy"] = (
             "default-src 'self'; "
-            "script-src 'self' 'unsafe-inline'; "
-            "style-src 'self' 'unsafe-inline'; "
+            "script-src 'self'; "
+            "style-src 'self'; "
             "img-src 'self' data: blob:; "
             "connect-src 'self' https: wss:; "
             "frame-ancestors 'none'"
@@ -375,6 +422,13 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
 
 app.add_middleware(SecurityHeadersMiddleware)
+
+# Trust only configured hostnames in production (blocks spoofed Host headers).
+# Empty list disables the middleware entirely so dev / tests are not affected.
+if settings.trusted_host_list:
+    from starlette.middleware.trustedhost import TrustedHostMiddleware
+
+    app.add_middleware(TrustedHostMiddleware, allowed_hosts=settings.trusted_host_list)
 
 # Phase 1 observability: warn on long-held DB connections per request
 app.add_middleware(
@@ -441,17 +495,29 @@ app.include_router(ws_runners_router)
 async def health():
     mgr = app.state.manager
     first_engine = next(iter(mgr.engines.values())) if mgr.engines else None
-    return await check_health(
+    payload = await check_health(
         first_engine,
         app.state.connector,
         app.state.redis,
         app.state.ai_client,
     )
+    # Return 503 when degraded so platform liveness probes (Railway, k8s) can
+    # actually evict / restart the pod. Plain 200 every time gave probes
+    # nothing to act on, hiding outages.
+    if payload.get("status") != "ok":
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(payload, status_code=503)
+    return payload
 
 
-@app.get("/health/pool")
+@app.get("/health/pool", dependencies=[Depends(require_auth)])
 async def health_pool():
-    """Live DB pool stats + recent slow queries + long-hold requests."""
+    """Live DB pool stats + recent slow queries + long-hold requests.
+
+    Auth-gated: leaks DB topology, partial SQL, and request-path latencies that
+    are useful for an attacker fingerprinting the deployment.
+    """
     stats = get_pool_stats(db_engine)
     monitor = getattr(app.state, "pool_monitor", None)
     return {

--- a/backend/app/market/sessions.py
+++ b/backend/app/market/sessions.py
@@ -13,18 +13,32 @@ Asset classes:
 
 from __future__ import annotations
 
+import enum
 from datetime import datetime, timedelta
 
+
+class AssetClass(str, enum.Enum):
+    """Supported asset classes. Subclasses ``str`` so existing string compares
+    keep working while gaining typo-safety at the producer side."""
+
+    FOREX = "forex"
+    METAL = "metal"
+    ENERGY = "energy"
+    INDEX = "index"
+    CRYPTO = "crypto"
+    STOCK = "stock"
+
+
 _RULES: dict[str, dict] = {
-    "forex": {"weekend": True, "daily_close": (22, 23), "reset_hour_utc": 22},
-    "metal": {"weekend": True, "daily_close": (22, 23), "reset_hour_utc": 22},
-    "energy": {"weekend": True, "daily_close": (22, 23), "reset_hour_utc": 22},
-    "index": {"weekend": True, "daily_close": (21, 22), "reset_hour_utc": 22},
-    "crypto": {"weekend": False, "daily_close": None, "reset_hour_utc": 0},
-    "stock": {"weekend": True, "daily_close": (21, 14), "reset_hour_utc": 21},
+    AssetClass.FOREX.value: {"weekend": True, "daily_close": (22, 23), "reset_hour_utc": 22},
+    AssetClass.METAL.value: {"weekend": True, "daily_close": (22, 23), "reset_hour_utc": 22},
+    AssetClass.ENERGY.value: {"weekend": True, "daily_close": (22, 23), "reset_hour_utc": 22},
+    AssetClass.INDEX.value: {"weekend": True, "daily_close": (21, 22), "reset_hour_utc": 22},
+    AssetClass.CRYPTO.value: {"weekend": False, "daily_close": None, "reset_hour_utc": 0},
+    AssetClass.STOCK.value: {"weekend": True, "daily_close": (21, 14), "reset_hour_utc": 21},
 }
 
-_DEFAULT_CLASS = "forex"
+_DEFAULT_CLASS = AssetClass.FOREX.value
 
 
 def _rules_for(asset_class: str | None) -> dict:

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -18,14 +18,16 @@ class Metrics:
         self._prefix = "metrics:"
 
     async def record_timing(self, name: str, duration_ms: float):
-        """Record a timing measurement."""
+        """Record a timing measurement. Best-effort: a Redis outage must not
+        crash the request handler, but a sustained metric write failure should
+        be visible at DEBUG so observability gaps don't go unnoticed."""
         key = f"{self._prefix}timing:{name}"
         try:
             await self.redis.lpush(key, str(duration_ms))
-            await self.redis.ltrim(key, 0, 999)  # keep last 1000
-            await self.redis.expire(key, 86400)  # 24h TTL
-        except Exception:
-            pass
+            await self.redis.ltrim(key, 0, 999)
+            await self.redis.expire(key, 86400)
+        except Exception as e:
+            logger.debug(f"metric record_timing[{name}] failed: {e!r}")
 
     async def increment_counter(self, name: str, amount: int = 1):
         """Increment a daily counter."""
@@ -33,8 +35,8 @@ class Metrics:
         try:
             await self.redis.incrby(key, amount)
             await self.redis.expire(key, 86400)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"metric increment_counter[{name}] failed: {e!r}")
 
     async def get_summary(self) -> dict:
         """Get summary of all metrics."""

--- a/backend/app/middleware/auth.py
+++ b/backend/app/middleware/auth.py
@@ -30,7 +30,7 @@ EXCLUDED_PREFIXES = (
 
 def _verify_jwt(token: str) -> dict | None:
     """Verify JWT and return payload."""
-    from jose import jwt
+    import jwt
 
     try:
         return jwt.decode(token, settings.secret_key, algorithms=["HS256"])

--- a/backend/app/middleware/rate_limit.py
+++ b/backend/app/middleware/rate_limit.py
@@ -110,6 +110,33 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
                 return parts[-1]
         return request.client.host if request.client else "unknown"
 
+    def _identity(self, request: Request) -> str:
+        """Identify the requester for rate-limit bucketing.
+
+        Prefers the authenticated subject decoded from the bearer token so a
+        single user behind a shared NAT does not absorb a stranger's quota
+        (and vice versa). Falls back to the trusted client IP when the request
+        is unauthenticated or the token cannot be decoded.
+
+        Explicitly rejects the literal ``__noauth__`` sentinel so a client
+        cannot forge ``Authorization: Bearer __noauth__`` and have every
+        request bucketed under one shared identity.
+        """
+        auth = request.headers.get("authorization") or ""
+        if auth.lower().startswith("bearer "):
+            token = auth[7:].strip()
+            if not token or token == "__noauth__":
+                return f"ip:{self._client_ip(request)}"
+            try:
+                from app.auth import verify_token
+
+                sub = verify_token(token)
+                if sub and sub != "__noauth__":
+                    return f"u:{sub}"
+            except Exception:
+                pass
+        return f"ip:{self._client_ip(request)}"
+
     async def dispatch(self, request: Request, call_next) -> Response:
         path = request.url.path
         if any(path.startswith(p) for p in self.exempt_prefixes):
@@ -117,15 +144,27 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
         redis_client: redis_lib.Redis | None = getattr(request.app.state, "redis", None)
         if redis_client is None:
+            # Fail closed for auth endpoints so a Redis outage cannot become an
+            # unrestricted brute-force window. Other paths fall through (the
+            # service is more useful than degraded protection on read APIs).
+            if path in self.AUTH_PATHS:
+                return JSONResponse(
+                    status_code=503,
+                    content={"error": "rate_limiter_unavailable"},
+                    headers={"Retry-After": "30"},
+                )
             return await call_next(request)
 
-        ip = self._client_ip(request)
         is_auth_path = path in self.AUTH_PATHS
         capacity = self.auth_capacity if is_auth_path else self.capacity
         refill = self.auth_refill if is_auth_path else self.refill_rate
-        # Shared bucket for all auth paths so an attacker cannot multiply the limit
-        # by spreading attempts across /login, /login/options, /login/verify, etc.
-        key = f"rl:{ip}:auth" if is_auth_path else f"rl:{ip}:{path}"
+        # Auth paths bucket by IP because the user is not authenticated yet.
+        # Other paths bucket by user when a valid bearer token is present, so
+        # one user's burst does not consume a co-located peer's quota.
+        if is_auth_path:
+            key = f"rl:ip:{self._client_ip(request)}:auth"
+        else:
+            key = f"rl:{self._identity(request)}:{path}"
         now = time.time()
 
         try:
@@ -142,12 +181,21 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             remaining = int(float(result[1]))
             retry_after = int(result[2])
         except Exception as e:
-            # Redis down — fail open rather than block legitimate traffic
+            # Redis hiccup mid-request — fail closed for auth, fail open for
+            # everything else. Avoids letting a Redis blip become a brute-force
+            # window while keeping read APIs available under partial outage.
+            if is_auth_path:
+                logger.warning(f"Rate limiter Redis error on auth path (fail-closed): {e!r}")
+                return JSONResponse(
+                    status_code=503,
+                    content={"error": "rate_limiter_unavailable"},
+                    headers={"Retry-After": "30"},
+                )
             logger.debug(f"Rate limiter Redis error (fail-open): {e}")
             return await call_next(request)
 
         if not allowed:
-            logger.warning(f"rate_limited ip={ip} path={path} retry_after={retry_after}s")
+            logger.warning(f"rate_limited key={key} path={path} retry_after={retry_after}s")
             return JSONResponse(
                 status_code=429,
                 content={"error": "rate_limited", "retry_after": retry_after},

--- a/backend/app/ml/integrity.py
+++ b/backend/app/ml/integrity.py
@@ -1,0 +1,50 @@
+"""HMAC integrity helpers for ML model binaries.
+
+Pickled model bytes go through ``joblib.load`` — equivalent to ``pickle.load``
+which executes arbitrary Python on deserialization. Any path that lets an
+attacker write to the ``ml_model_logs.model_binary`` column (SQL injection,
+compromised admin, malicious migration) becomes RCE.
+
+We mitigate by signing the blob with HMAC-SHA256 at save time and rejecting
+the load when the digest does not match a fresh recompute. The signing key is
+the application ``SECRET_KEY``; rotating it invalidates all prior models, which
+is the desired behavior because rotation is itself a security event.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+from loguru import logger
+
+from app.config import settings
+
+
+def compute_model_digest(model_bytes: bytes) -> str:
+    """Hex HMAC-SHA256 of ``model_bytes`` keyed by SECRET_KEY."""
+    key = settings.secret_key.encode() if settings.secret_key else b""
+    return hmac.new(key, model_bytes, hashlib.sha256).hexdigest()
+
+
+def verify_model_digest(model_bytes: bytes, expected_digest: str | None, *, context: str) -> bool:
+    """Return True iff the digest matches. Logs a warning on mismatch.
+
+    Empty / missing ``expected_digest`` is treated as a verification failure
+    — a legacy row written before this check existed must be re-trained
+    rather than loaded blindly. Set the env var ``ML_DIGEST_REQUIRED=0`` to
+    grant a one-time grace period during rollout (logs WARN but allows load).
+    """
+    import os
+
+    if not expected_digest:
+        if os.getenv("ML_DIGEST_REQUIRED", "1") == "0":
+            logger.warning(f"ml_digest missing [{context}] — allowed by ML_DIGEST_REQUIRED=0 grace flag")
+            return True
+        logger.error(f"ml_digest missing [{context}] — refusing to load (set ML_DIGEST_REQUIRED=0 for grace period)")
+        return False
+    actual = compute_model_digest(model_bytes)
+    if not hmac.compare_digest(actual, expected_digest):
+        logger.error(f"ml_digest mismatch [{context}] — refusing to load (possible tampering)")
+        return False
+    return True

--- a/backend/app/risk/manager.py
+++ b/backend/app/risk/manager.py
@@ -70,6 +70,7 @@ class RiskManager:
         price_decimals: int = 2,
         sl_atr_mult: float = 1.5,
         tp_atr_mult: float = 2.0,
+        contract_size: float = 100.0,
     ):
         self.max_risk_per_trade = max_risk_per_trade
         self.max_daily_loss = max_daily_loss
@@ -81,7 +82,12 @@ class RiskManager:
         self.price_decimals = price_decimals
         self.sl_atr_mult = sl_atr_mult
         self.tp_atr_mult = tp_atr_mult
-        # Regime-aware risk
+        # Contract size is the per-lot multiplier MT5 reports for the symbol.
+        # P&L per lot per price unit = contract_size, so accurate lot sizing
+        # MUST go through it. Older code multiplied pip_value*100 and assumed
+        # that equalled contract_size — only true for GOLD, broken for other
+        # symbols (OIL ×10 undersize, BTC ×100 undersize, USDJPY ×10 oversize).
+        self.contract_size = contract_size
         self.current_regime = "normal"
         self.regime_lot_multiplier = 1.0
 
@@ -99,31 +105,35 @@ class RiskManager:
     def calculate_lot_size(
         self,
         balance: float,
-        sl_pips: float,
+        sl_distance: float,
         pip_value: float | None = None,
         atr_pct: float | None = None,
         slippage_pips: float = DEFAULT_SLIPPAGE_PIPS,
         commission_pct: float = DEFAULT_COMMISSION_PCT,
     ) -> float:
-        if sl_pips <= 0:
+        """Compute lot size from a stop-loss distance in **price units** (not pips).
+
+        Identity: P&L_per_lot = sl_distance × contract_size. Lot count therefore
+        equals risk_budget ÷ that quantity. The legacy ``pip_value × 100`` form
+        only matched contract_size for GOLD; this version is correct for any
+        broker symbol whose contract_size is set in SYMBOL_PROFILES.
+        """
+        if sl_distance <= 0:
             return MIN_LOT
         pv = pip_value if pip_value is not None else self.pip_value
 
-        # Account for slippage in effective SL distance
-        effective_sl = sl_pips + slippage_pips
+        # Convert slippage (in pips) to a price-unit cushion before adding.
+        effective_sl = sl_distance + slippage_pips * pv
 
-        # Risk budget minus estimated commission
         risk_budget = (balance * self.max_risk_per_trade) * (1 - commission_pct)
-        lot = risk_budget / (effective_sl * pv * 100)
+        lot = risk_budget / (effective_sl * self.contract_size)
 
-        # Volatility adjustment
         if atr_pct is not None:
             if atr_pct > HIGH_VOL_THRESHOLD:
                 lot *= HIGH_VOL_LOT_FACTOR
             elif atr_pct < LOW_VOL_THRESHOLD:
                 lot *= LOW_VOL_LOT_FACTOR
 
-        # Regime adjustment
         lot *= self.regime_lot_multiplier
 
         lot = round(min(lot, self.max_lot), 2)
@@ -132,30 +142,29 @@ class RiskManager:
     def calculate_kelly_size(
         self,
         balance: float,
-        sl_pips: float,
+        sl_distance: float,
         win_rate: float,
         avg_win: float,
         avg_loss: float,
         pip_value: float | None = None,
     ) -> float:
-        """Kelly Criterion position sizing (fractional Kelly = 0.25x for safety)."""
-        if avg_loss <= 0 or win_rate <= 0:
-            return self.calculate_lot_size(balance, sl_pips, pip_value)
+        """Kelly Criterion position sizing (fractional Kelly = 0.25x for safety).
 
-        # Kelly fraction: f* = (p * b - q) / b
-        # where p=win_rate, q=1-p, b=avg_win/avg_loss
+        ``sl_distance`` is a price-unit value matching ``calculate_lot_size``.
+        """
+        if avg_loss <= 0 or win_rate <= 0:
+            return self.calculate_lot_size(balance, sl_distance, pip_value)
+
         b = avg_win / avg_loss
         q = 1 - win_rate
         kelly = (win_rate * b - q) / b
 
-        # Fractional Kelly for safety
         kelly = max(kelly * KELLY_FRACTION, KELLY_MIN_RISK)
         kelly = min(kelly, self.max_risk_per_trade * KELLY_MAX_RISK_MULT)
 
-        pv = pip_value if pip_value is not None else self.pip_value
-        if sl_pips <= 0:
+        if sl_distance <= 0:
             return MIN_LOT
-        lot = (balance * kelly) / (sl_pips * pv * 100)
+        lot = (balance * kelly) / (sl_distance * self.contract_size)
         lot = round(min(lot, self.max_lot), 2)
         return max(lot, MIN_LOT)
 

--- a/backend/app/strategy/ml_strategy.py
+++ b/backend/app/strategy/ml_strategy.py
@@ -27,16 +27,20 @@ from app.strategy.indicators import atr
 
 
 class MLStrategy(BaseStrategy):
+    # Throttle DB lookups when no model exists yet (e.g. fresh symbol pre-train).
+    # We re-poll every N candles instead of every tick so a newly-trained model
+    # gets picked up automatically without spamming the DB on each call.
+    _MODEL_RECHECK_EVERY = 20
+
     def __init__(self, model_path: str | None = None, confidence_threshold: float = 0.5, symbol: str = "GOLD"):
-        # Default model path is symbol-derived — no XAUUSD-specific fallback.
         self._model_path = model_path or f"models/{symbol.lower()}_signal.pkl"
         self._confidence_threshold = confidence_threshold
         self._symbol = symbol
         self._model = None
         self._feature_columns = FEATURE_COLUMNS
         self._model_loaded = False
+        self._missing_recheck_count = 0
 
-        # Prefer explicit model_path when provided; otherwise use symbol-derived path.
         load_path = self._model_path
         if Path(load_path).exists():
             try:
@@ -49,8 +53,19 @@ class MLStrategy(BaseStrategy):
                 logger.warning(f"Failed to load model from file: {e}")
 
     async def _ensure_model(self):
-        """Load model from DB if not already loaded. Filters by symbol."""
-        if self._model_loaded:
+        """Load model from DB if not already loaded. Filters by symbol.
+
+        When no model has been trained yet, this method previously set
+        ``_model_loaded=True`` and never re-checked, so a model trained later
+        (manual /retrain or weekly job) was ignored until the engine restarted.
+        We now keep ``_model_loaded=False`` and only re-check the DB every
+        ``_MODEL_RECHECK_EVERY`` candles so the lookup cost is bounded but the
+        strategy actually picks up newly-trained models in-flight.
+        """
+        if self._model is not None and self._model_loaded:
+            return
+        if not self._model_loaded and self._missing_recheck_count > 0:
+            self._missing_recheck_count -= 1
             return
 
         try:
@@ -87,15 +102,29 @@ class MLStrategy(BaseStrategy):
                     log = result.scalar_one_or_none()
 
                 if log and log.model_binary:
+                    from app.ml.integrity import verify_model_digest
+
+                    if not verify_model_digest(
+                        log.model_binary, log.model_digest, context=f"ml_strategy[{self._symbol}]"
+                    ):
+                        logger.error(
+                            f"ML model integrity check failed for {self._symbol} — leaving strategy without a model"
+                        )
+                        self._missing_recheck_count = self._MODEL_RECHECK_EVERY
+                        return
                     buf = io.BytesIO(log.model_binary)
                     data = joblib.load(buf)
                     self._model = data["model"]
                     self._feature_columns = data.get("features", FEATURE_COLUMNS)
                     self._model_loaded = True
+                    self._missing_recheck_count = 0
                     logger.info(f"ML model loaded from DB: {log.model_name} (symbol={self._symbol})")
                 else:
-                    logger.warning(f"No trained ML model found for {self._symbol} — Train a model on the ML page first")
-                    self._model_loaded = True  # no model exists, don't keep retrying
+                    logger.warning(
+                        f"No trained ML model found for {self._symbol} — re-checking in "
+                        f"{self._MODEL_RECHECK_EVERY} candles (train via /symbols/{{symbol}}/retrain)"
+                    )
+                    self._missing_recheck_count = self._MODEL_RECHECK_EVERY
         except Exception as e:
             logger.warning(f"Failed to load ML model from DB: {e} — will retry next candle")
 

--- a/backend/mcp_server/guardrails.py
+++ b/backend/mcp_server/guardrails.py
@@ -80,7 +80,11 @@ class TradingGuardrails:
         self.redis = redis
 
     def get_rollout_mode(self) -> str:
-        """Get current rollout mode from env or default."""
+        """Synchronous fallback used only when no Redis connection is available
+        (tests, init-time checks). Production callers must use the async
+        :meth:`get_persisted_rollout_mode` so a UI-driven downgrade (e.g.
+        live → paper after an incident) actually takes effect.
+        """
         mode = os.environ.get("ROLLOUT_MODE", "shadow")
         return mode if mode in ROLLOUT_MODES else "shadow"
 
@@ -92,24 +96,35 @@ class TradingGuardrails:
         os.environ["ROLLOUT_MODE"] = mode
 
     async def get_persisted_rollout_mode(self) -> str:
-        """Get rollout mode from Redis (or fall back to env)."""
-        val = await self.redis.get(f"{_KEY_PREFIX}:rollout_mode")
+        """Get rollout mode. Redis is the source of truth — the env var is
+        only used as a bootstrap default before any UI write has happened.
+        Otherwise an env-set ``ROLLOUT_MODE=live`` would silently override an
+        operator's UI downgrade after an incident.
+        """
+        try:
+            val = await self.redis.get(f"{_KEY_PREFIX}:rollout_mode")
+        except Exception:
+            val = None
         if val:
             mode = val.decode() if isinstance(val, bytes) else str(val)
             if mode in ROLLOUT_MODES:
                 return mode
         return self.get_rollout_mode()
 
+    async def check_rollout_mode_async(self, lot: float) -> GuardrailResult:
+        """Async variant that reads Redis first. Prefer this in MCP tool code
+        paths so live-mode downgrades from the UI take effect immediately."""
+        mode = await self.get_persisted_rollout_mode()
+        return self._evaluate_rollout(mode, lot)
+
     def check_rollout_mode(self, lot: float) -> GuardrailResult:
-        """Check if the current rollout mode allows execution, and enforce lot caps.
-
-        Returns:
-            GuardrailResult with allowed=True if execution should proceed,
-            or allowed=False with reason for shadow/paper modes.
-            For micro mode, the lot is capped but execution proceeds.
+        """Sync fallback. Prefer :meth:`check_rollout_mode_async` from any
+        coroutine context so the Redis-persisted mode wins over a stale env
+        value.
         """
-        mode = self.get_rollout_mode()
+        return self._evaluate_rollout(self.get_rollout_mode(), lot)
 
+    def _evaluate_rollout(self, mode: str, lot: float) -> GuardrailResult:
         if mode == "shadow":
             return GuardrailResult(False, "SHADOW MODE: order logged but not executed")
 

--- a/backend/mcp_server/tools/risk.py
+++ b/backend/mcp_server/tools/risk.py
@@ -70,7 +70,9 @@ def calculate_lot(
         Dict with lot size.
     """
     rm = _get_risk_manager(symbol)
-    lot = rm.calculate_lot_size(balance=balance, sl_pips=sl_pips, atr_pct=atr_pct)
+    # `sl_pips` here is conventionally a price-unit distance — pass through to
+    # the renamed kwarg without semantic change.
+    lot = rm.calculate_lot_size(balance=balance, sl_distance=sl_pips, atr_pct=atr_pct)
     return {"symbol": symbol, "lot": lot, "balance": balance, "sl_pips": sl_pips}
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,7 +18,7 @@ lightgbm==4.6.0
 scikit-learn==1.5.2
 statsmodels>=0.14.0
 joblib==1.4.2
-python-jose[cryptography]==3.3.0
+PyJWT[crypto]>=2.10.1
 passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
 webauthn==2.7.1
@@ -27,3 +27,4 @@ arch>=7.0
 hmmlearn>=0.3
 filterpy>=1.4
 cvxpy>=1.4
+sentry-sdk[fastapi]==2.20.0

--- a/backend/tests/unit/test_risk_manager.py
+++ b/backend/tests/unit/test_risk_manager.py
@@ -23,45 +23,45 @@ class TestCalculateLotSize:
         )
 
     def test_basic_lot_size(self):
-        lot = self.rm.calculate_lot_size(balance=10000, sl_pips=20)
+        lot = self.rm.calculate_lot_size(balance=10000, sl_distance=20)
         assert lot > 0
         assert lot <= self.rm.max_lot
 
     def test_zero_sl_returns_min_lot(self):
-        lot = self.rm.calculate_lot_size(balance=10000, sl_pips=0)
+        lot = self.rm.calculate_lot_size(balance=10000, sl_distance=0)
         assert lot == MIN_LOT
 
     def test_negative_sl_returns_min_lot(self):
-        lot = self.rm.calculate_lot_size(balance=10000, sl_pips=-5)
+        lot = self.rm.calculate_lot_size(balance=10000, sl_distance=-5)
         assert lot == MIN_LOT
 
     def test_lot_capped_at_max(self):
         rm = RiskManager(max_risk_per_trade=0.5, max_lot=0.5)
-        lot = rm.calculate_lot_size(balance=100000, sl_pips=1)
+        lot = rm.calculate_lot_size(balance=100000, sl_distance=1)
         assert lot <= 0.5
 
     def test_lot_floor_at_min(self):
-        lot = self.rm.calculate_lot_size(balance=10, sl_pips=100)
+        lot = self.rm.calculate_lot_size(balance=10, sl_distance=100)
         assert lot == MIN_LOT
 
     def test_high_volatility_reduces_lot(self):
-        lot_normal = self.rm.calculate_lot_size(balance=10000, sl_pips=20, atr_pct=None)
-        lot_high_vol = self.rm.calculate_lot_size(balance=10000, sl_pips=20, atr_pct=HIGH_VOL_THRESHOLD + 0.1)
+        lot_normal = self.rm.calculate_lot_size(balance=10000, sl_distance=20, atr_pct=None)
+        lot_high_vol = self.rm.calculate_lot_size(balance=10000, sl_distance=20, atr_pct=HIGH_VOL_THRESHOLD + 0.1)
         assert lot_high_vol <= lot_normal
 
     def test_low_volatility_increases_lot(self):
-        lot_normal = self.rm.calculate_lot_size(balance=10000, sl_pips=20, atr_pct=0.3)
-        lot_low_vol = self.rm.calculate_lot_size(balance=10000, sl_pips=20, atr_pct=LOW_VOL_THRESHOLD - 0.1)
+        lot_normal = self.rm.calculate_lot_size(balance=10000, sl_distance=20, atr_pct=0.3)
+        lot_low_vol = self.rm.calculate_lot_size(balance=10000, sl_distance=20, atr_pct=LOW_VOL_THRESHOLD - 0.1)
         assert lot_low_vol >= lot_normal
 
     def test_slippage_and_commission(self):
-        lot_default = self.rm.calculate_lot_size(balance=10000, sl_pips=20)
-        lot_high_slip = self.rm.calculate_lot_size(balance=10000, sl_pips=20, slippage_pips=10.0)
+        lot_default = self.rm.calculate_lot_size(balance=10000, sl_distance=20)
+        lot_high_slip = self.rm.calculate_lot_size(balance=10000, sl_distance=20, slippage_pips=10.0)
         assert lot_high_slip < lot_default
 
     def test_custom_pip_value(self):
-        lot = self.rm.calculate_lot_size(balance=10000, sl_pips=20, pip_value=10.0)
-        lot_default = self.rm.calculate_lot_size(balance=10000, sl_pips=20, pip_value=1.0)
+        lot = self.rm.calculate_lot_size(balance=10000, sl_distance=20, pip_value=10.0)
+        lot_default = self.rm.calculate_lot_size(balance=10000, sl_distance=20, pip_value=1.0)
         assert lot < lot_default  # higher pip_value → smaller lot
 
 
@@ -72,7 +72,7 @@ class TestCalculateKellySize:
     def test_kelly_basic(self):
         lot = self.rm.calculate_kelly_size(
             balance=10000,
-            sl_pips=20,
+            sl_distance=20,
             win_rate=0.6,
             avg_win=100,
             avg_loss=50,
@@ -83,31 +83,31 @@ class TestCalculateKellySize:
     def test_kelly_zero_loss_falls_back(self):
         lot = self.rm.calculate_kelly_size(
             balance=10000,
-            sl_pips=20,
+            sl_distance=20,
             win_rate=0.6,
             avg_win=100,
             avg_loss=0,
         )
         # Falls back to calculate_lot_size
-        expected = self.rm.calculate_lot_size(balance=10000, sl_pips=20)
+        expected = self.rm.calculate_lot_size(balance=10000, sl_distance=20)
         assert lot == expected
 
     def test_kelly_zero_win_rate_falls_back(self):
         lot = self.rm.calculate_kelly_size(
             balance=10000,
-            sl_pips=20,
+            sl_distance=20,
             win_rate=0,
             avg_win=100,
             avg_loss=50,
         )
-        expected = self.rm.calculate_lot_size(balance=10000, sl_pips=20)
+        expected = self.rm.calculate_lot_size(balance=10000, sl_distance=20)
         assert lot == expected
 
     def test_kelly_negative_kelly_uses_min(self):
         # Bad strategy: low win rate
         lot = self.rm.calculate_kelly_size(
             balance=10000,
-            sl_pips=20,
+            sl_distance=20,
             win_rate=0.2,
             avg_win=10,
             avg_loss=100,
@@ -118,7 +118,7 @@ class TestCalculateKellySize:
     def test_kelly_capped_at_max_risk(self):
         lot = self.rm.calculate_kelly_size(
             balance=10000,
-            sl_pips=20,
+            sl_distance=20,
             win_rate=0.9,
             avg_win=500,
             avg_loss=10,
@@ -129,7 +129,7 @@ class TestCalculateKellySize:
     def test_kelly_zero_sl(self):
         lot = self.rm.calculate_kelly_size(
             balance=10000,
-            sl_pips=0,
+            sl_distance=0,
             win_rate=0.6,
             avg_win=100,
             avg_loss=50,


### PR DESCRIPTION
## Summary
- **Symbol auto-trade**: newly added symbols auto-start engine + seed history + ML retrain on /symbols POST + toggle, no manual /api/bot/start needed
- **Money correctness (CRITICAL)**: lot-sizing formula was wrong for OIL/BTC/USDJPY (10×–100× off). Replaced `pip_value × 100` with `contract_size`
- **OWASP top 10**: PyJWT migration (CVE-2024-33663/33664), ML model HMAC integrity, /ws-token JTI revocation, WebAuthn first-register protection, input bounds (webhook nonce, credential blob), SECRET_KEY/VAULT_MASTER_KEY ≥32 chars, CORS wildcard guard, path-traversal hardening on symbol → joblib.load, rate-limit fail-closed on auth paths, rollout-mode Redis-first
- **Reliability**: gather() exceptions surfaced, isolated session for `_log_event`, ml_strategy live model recheck, health 503 when degraded, audit log failure visibility
- **Perf/DB**: defer model_binary blob, batched cleanup DELETE, daily reset per asset_class hour, pool sized for Railway Hobby. 3 alembic migrations: indexes, JSON→JSONB, model_digest column
- **Observability**: Sentry SDK (gated by SENTRY_DSN), startup banners for risky configs, per-user rate-limit identity, daily DB backup APScheduler job
- **Helpers**: `transaction()` CM, `make_authed_router`, `AssetClass` enum, ML integrity helpers

## Diff scope
- 30 files modified, 5 new (3 alembic + 2 helper modules)
- ~1.3k insertions, ~250 deletions

## Test plan
- [x] `ruff check` — clean
- [x] `pytest` — 454 passed (37 deselected: claude-agent-sdk dep)
- [ ] Manual: paper-trade smoke test on OIL/BTC/USDJPY (lot magnitudes change)
- [ ] Manual: POST /api/symbols → toggle ON → verify auto-trade kicks in
- [ ] Manual: alembic upgrade head on staging
- [ ] Manual: set `ML_DIGEST_REQUIRED=0` for grace period, retrain all symbols, unset

## Deploy notes
1. `pip install -r requirements.txt` (PyJWT replaces python-jose, sentry-sdk added)
2. `alembic upgrade head` — index migration (fast). JSONB migration in maintenance window (ACCESS EXCLUSIVE locks)
3. Existing ML models lack `model_digest` — set `ML_DIGEST_REQUIRED=0` for one cycle, retrain, unset
4. New env vars: `TRUSTED_HOSTS`, `VAULT_SALT`, `ENABLE_DB_BACKUPS=1`, `SENTRY_DSN`, `WEBAUTHN_SETUP_TOKEN` (only for first-passkey-setup)
5. Verify `SECRET_KEY` ≥32 chars + `VAULT_MASTER_KEY` ≥32 chars (startup will fail otherwise)
6. Reject `CORS_ORIGINS=*` (startup will fail)

## Breaking
- `RiskManager.calculate_lot_size(sl_distance, ...)` — kwarg renamed (was `sl_pips`). Backtest + tests updated. MCP `calculate_lot` wrapper still accepts `sl_pips` for AI agent stability
- `LoginVerifyRequest` now requires `challenge_key` field — frontend WebAuthn login (currently disabled) needs update before re-enable

🤖 Generated with [Claude Code](https://claude.com/claude-code)